### PR TITLE
Animation state machine improvements

### DIFF
--- a/source/shared/core/animations/states/LegsJumpSideAnimationState.cpp
+++ b/source/shared/core/animations/states/LegsJumpSideAnimationState.cpp
@@ -23,23 +23,14 @@ LegsJumpSideAnimationState::LegsJumpSideAnimationState(
 {
 }
 
-void LegsJumpSideAnimationState::Enter(Soldier& soldier)
-{
-    jumping_direction_left_ = soldier.control.was_running_left;
-    both_direction_keys_pressed_ = soldier.control.left && soldier.control.right;
-}
-
 std::optional<std::shared_ptr<AnimationState>> LegsJumpSideAnimationState::HandleInput(
   Soldier& soldier)
 {
     if (!soldier.control.left || !soldier.control.right) {
-        both_direction_keys_pressed_ = false;
         soldier.control.was_running_left = soldier.control.left;
     }
-    if (!both_direction_keys_pressed_ && soldier.control.left && soldier.control.right) {
-        both_direction_keys_pressed_ = true;
-    }
-    jumping_direction_left_ = soldier.control.was_running_left;
+
+    bool jumping_direction_left = soldier.control.was_running_left;
 
     if (soldier.control.prone) {
         return std::make_shared<LegsProneAnimationState>(animation_data_manager_);
@@ -101,7 +92,7 @@ std::optional<std::shared_ptr<AnimationState>> LegsJumpSideAnimationState::Handl
         }
     }
 
-    if (!jumping_direction_left_) {
+    if (!jumping_direction_left) {
         if ((GetFrame() > 3) && (GetFrame() < 11)) {
             glm::vec2 particle_force = soldier.particle.GetForce();
             particle_force.x = PhysicsConstants::JUMPDIRSPEED;
@@ -110,7 +101,7 @@ std::optional<std::shared_ptr<AnimationState>> LegsJumpSideAnimationState::Handl
         }
     }
 
-    if (jumping_direction_left_) {
+    if (jumping_direction_left) {
         if (GetType() == AnimationType::JumpSide) {
             if ((GetFrame() > 3) && (GetFrame() < 11)) {
                 glm::vec2 particle_force = soldier.particle.GetForce();
@@ -124,7 +115,7 @@ std::optional<std::shared_ptr<AnimationState>> LegsJumpSideAnimationState::Handl
     return std::nullopt;
 }
 
-void LegsJumpSideAnimationState::Update(Soldier& soldier, const PhysicsEvents& physics_events)
+void LegsJumpSideAnimationState::Update(Soldier& soldier, const PhysicsEvents& /*physics_events*/)
 {
     soldier.stance = PhysicsConstants::STANCE_STAND;
 }

--- a/source/shared/core/animations/states/LegsJumpSideAnimationState.hpp
+++ b/source/shared/core/animations/states/LegsJumpSideAnimationState.hpp
@@ -15,7 +15,6 @@ public:
     LegsJumpSideAnimationState(const AnimationDataManager& animation_data_manager);
     ~LegsJumpSideAnimationState() override = default;
 
-    void Enter(Soldier& soldier) final;
     std::optional<std::shared_ptr<AnimationState>> HandleInput(Soldier& soldier) final;
     void Update(Soldier& soldier, const PhysicsEvents& physics_events) final;
 
@@ -23,9 +22,6 @@ public:
 
 private:
     const AnimationDataManager& animation_data_manager_;
-
-    bool jumping_direction_left_{ false };
-    bool both_direction_keys_pressed_{ false };
 };
 } // namespace Soldank
 

--- a/source/shared/core/animations/states/LegsProneMoveAnimationState.cpp
+++ b/source/shared/core/animations/states/LegsProneMoveAnimationState.cpp
@@ -17,24 +17,9 @@ LegsProneMoveAnimationState::LegsProneMoveAnimationState(
 {
 }
 
-void LegsProneMoveAnimationState::Enter(Soldier& soldier)
-{
-    moving_direction_left_ = soldier.control.left;
-    both_direction_keys_pressed_ = soldier.control.left && soldier.control.right;
-}
-
 std::optional<std::shared_ptr<AnimationState>> LegsProneMoveAnimationState::HandleInput(
   Soldier& soldier)
 {
-    if (!soldier.control.left || !soldier.control.right) {
-        both_direction_keys_pressed_ = false;
-        moving_direction_left_ = soldier.control.left;
-    }
-    if (!both_direction_keys_pressed_ && soldier.control.left && soldier.control.right) {
-        both_direction_keys_pressed_ = true;
-        moving_direction_left_ = !moving_direction_left_;
-    }
-
     if (!soldier.control.left && !soldier.control.right) {
         auto new_state = std::make_shared<LegsProneAnimationState>(animation_data_manager_);
         new_state->SetFrame(26);
@@ -42,17 +27,8 @@ std::optional<std::shared_ptr<AnimationState>> LegsProneMoveAnimationState::Hand
     }
 
     if (soldier.on_ground) {
-        bool was_holding_left = soldier.control.left;
-        bool was_holding_right = soldier.control.right;
-        if (moving_direction_left_) {
-            soldier.control.right = false;
-        } else {
-            soldier.control.left = false;
-        }
         auto maybe_rolling_animation_state =
           CommonAnimationStateTransitions::TryTransitionToRolling(soldier, animation_data_manager_);
-        soldier.control.left = was_holding_left;
-        soldier.control.right = was_holding_right;
         if (maybe_rolling_animation_state.has_value()) {
             return *maybe_rolling_animation_state;
         }
@@ -78,7 +54,7 @@ void LegsProneMoveAnimationState::Update(Soldier& soldier, const PhysicsEvents& 
 
     if ((GetFrame() < 4) || (GetFrame() > 14)) {
         if (soldier.on_ground) {
-            if (moving_direction_left_) {
+            if (soldier.control.left) {
                 glm::vec2 particle_force = soldier.particle.GetForce();
                 particle_force.x = -PhysicsConstants::PRONESPEED;
                 soldier.particle.SetForce(particle_force);

--- a/source/shared/core/animations/states/LegsProneMoveAnimationState.hpp
+++ b/source/shared/core/animations/states/LegsProneMoveAnimationState.hpp
@@ -15,15 +15,11 @@ public:
     LegsProneMoveAnimationState(const AnimationDataManager& animation_data_manager);
     ~LegsProneMoveAnimationState() override = default;
 
-    void Enter(Soldier& soldier) final;
     std::optional<std::shared_ptr<AnimationState>> HandleInput(Soldier& soldier) final;
     void Update(Soldier& soldier, const PhysicsEvents& physics_events) final;
 
 private:
     const AnimationDataManager& animation_data_manager_;
-
-    bool moving_direction_left_{ false };
-    bool both_direction_keys_pressed_{ false };
 };
 } // namespace Soldank
 

--- a/source/shared/core/animations/states/LegsRunAnimationState.hpp
+++ b/source/shared/core/animations/states/LegsRunAnimationState.hpp
@@ -15,17 +15,11 @@ public:
     LegsRunAnimationState(const AnimationDataManager& animation_data_manager);
     ~LegsRunAnimationState() override = default;
 
-    void Enter(Soldier& soldier) final;
     std::optional<std::shared_ptr<AnimationState>> HandleInput(Soldier& soldier) final;
     void Update(Soldier& soldier, const PhysicsEvents& physics_events) final;
 
 private:
-    bool IsRunningLeft(const Soldier& soldier) const;
-
     const AnimationDataManager& animation_data_manager_;
-
-    bool was_holding_left_{ false };
-    bool was_holding_right_{ false };
 };
 } // namespace Soldank
 

--- a/source/shared/core/animations/states/LegsRunBackAnimationState.cpp
+++ b/source/shared/core/animations/states/LegsRunBackAnimationState.cpp
@@ -21,12 +21,6 @@ LegsRunBackAnimationState::LegsRunBackAnimationState(
 {
 }
 
-void LegsRunBackAnimationState::Enter(Soldier& soldier)
-{
-    was_holding_left_ = soldier.control.left;
-    was_holding_right_ = soldier.control.right;
-}
-
 std::optional<std::shared_ptr<AnimationState>> LegsRunBackAnimationState::HandleInput(
   Soldier& soldier)
 {
@@ -35,17 +29,8 @@ std::optional<std::shared_ptr<AnimationState>> LegsRunBackAnimationState::Handle
     }
 
     if (soldier.on_ground) {
-        bool was_holding_left = soldier.control.left;
-        bool was_holding_right = soldier.control.right;
-        if (IsRunningLeft(soldier)) {
-            soldier.control.right = false;
-        } else {
-            soldier.control.left = false;
-        }
         auto maybe_rolling_animation_state =
           CommonAnimationStateTransitions::TryTransitionToRolling(soldier, animation_data_manager_);
-        soldier.control.left = was_holding_left;
-        soldier.control.right = was_holding_right;
         if (maybe_rolling_animation_state.has_value()) {
             return *maybe_rolling_animation_state;
         }
@@ -60,8 +45,6 @@ std::optional<std::shared_ptr<AnimationState>> LegsRunBackAnimationState::Handle
         }
 
         if (soldier.control.up) {
-            was_holding_right_ = soldier.control.right;
-            was_holding_left_ = soldier.control.left;
             return std::nullopt;
         }
 
@@ -69,20 +52,16 @@ std::optional<std::shared_ptr<AnimationState>> LegsRunBackAnimationState::Handle
     }
 
     if (soldier.control.up && soldier.on_ground) {
-        soldier.control.was_running_left = IsRunningLeft(soldier);
+        soldier.control.was_running_left = soldier.control.left;
         return std::make_shared<LegsJumpSideAnimationState>(animation_data_manager_);
     }
 
-    if (!was_holding_left_ || !soldier.control.right) {
-        if (soldier.control.left && soldier.direction == -1) {
-            return std::make_shared<LegsRunAnimationState>(animation_data_manager_);
-        }
+    if (soldier.control.left && soldier.direction == -1) {
+        return std::make_shared<LegsRunAnimationState>(animation_data_manager_);
     }
 
-    if (!was_holding_right_ || !soldier.control.left) {
-        if (soldier.control.right && soldier.direction == 1) {
-            return std::make_shared<LegsRunAnimationState>(animation_data_manager_);
-        }
+    if (soldier.control.right && soldier.direction == 1) {
+        return std::make_shared<LegsRunAnimationState>(animation_data_manager_);
     }
 
     // if using jets, reset animation because first frame looks like "directional" jetting
@@ -94,12 +73,10 @@ std::optional<std::shared_ptr<AnimationState>> LegsRunBackAnimationState::Handle
         return std::make_shared<LegsRunBackAnimationState>(animation_data_manager_);
     }
 
-    was_holding_right_ = soldier.control.right;
-    was_holding_left_ = soldier.control.left;
     return std::nullopt;
 }
 
-void LegsRunBackAnimationState::Update(Soldier& soldier, const PhysicsEvents& physics_events)
+void LegsRunBackAnimationState::Update(Soldier& soldier, const PhysicsEvents& /*physics_events*/)
 {
     soldier.stance = PhysicsConstants::STANCE_STAND;
 
@@ -124,28 +101,5 @@ void LegsRunBackAnimationState::Update(Soldier& soldier, const PhysicsEvents& ph
             soldier.particle.SetForce(particle_force);
         }
     }
-}
-
-bool LegsRunBackAnimationState::IsRunningLeft(const Soldier& soldier) const
-{
-    if (soldier.control.left && soldier.control.right) {
-        if (soldier.direction == 1) {
-            if (!was_holding_right_) {
-                // right was just pressed so should be running right
-                return false;
-            }
-        }
-
-        if (soldier.direction == -1) {
-            if (!was_holding_left_) {
-                // left was just pressed so should be running left
-                return true;
-            }
-        }
-
-        return soldier.direction == 1;
-    }
-
-    return soldier.control.left;
 }
 } // namespace Soldank

--- a/source/shared/core/animations/states/LegsRunBackAnimationState.hpp
+++ b/source/shared/core/animations/states/LegsRunBackAnimationState.hpp
@@ -15,17 +15,11 @@ public:
     LegsRunBackAnimationState(const AnimationDataManager& animation_data_manager);
     ~LegsRunBackAnimationState() override = default;
 
-    void Enter(Soldier& soldier) final;
     std::optional<std::shared_ptr<AnimationState>> HandleInput(Soldier& soldier) final;
     void Update(Soldier& soldier, const PhysicsEvents& physics_events) final;
 
 private:
-    bool IsRunningLeft(const Soldier& soldier) const;
-
     const AnimationDataManager& animation_data_manager_;
-
-    bool was_holding_left_{ false };
-    bool was_holding_right_{ false };
 };
 } // namespace Soldank
 


### PR DESCRIPTION
Some of the classes of animation state machine are using Enter() method to setup initial state depending on the previous state. It's not good because it's preventing reproducing the state machine from network requests.

The direction states needed to know from which direction the player was moving to corretly handle pressing both left and right direction keys at the same time. This handling has been moved to be client's responsibility when registering the input. The core logic doesn't need to worry about it anymore.

This PR is cleaning up to remove unnecessary initial state setting.