### PR TITLE
Refactor state usage

### DIFF
--- a/source/client/application/Application.cpp
+++ b/source/client/application/Application.cpp
@@ -608,13 +608,13 @@ void Application::Run()
             client_state_->camera = { 0.0F, 0.0F };
         }
     });
-    world_->SetPostWorldUpdateCallback([&](const State& /*state*/) {});
+    world_->SetPostWorldUpdateCallback([&](const StateManager& /*state_manager*/) {});
     world_->SetPostGameLoopIterationCallback(
-      [&](const State& /*state*/, double frame_percent, int last_fps) {
+      [&](const StateManager& state_manager, double frame_percent, int last_fps) {
           if (!client_state_->objects_interpolation) {
               frame_percent = 1.0F;
           }
-          scene.Render(*world_->GetStateManager(), *client_state_, frame_percent, last_fps);
+          scene.Render(state_manager, *client_state_, frame_percent, last_fps);
 
           window_->SwapBuffers();
           window_->PollInput();

--- a/source/client/application/Application.cpp
+++ b/source/client/application/Application.cpp
@@ -615,8 +615,7 @@ void Application::Run()
           if (!client_state_->objects_interpolation) {
               frame_percent = 1.0F;
           }
-          scene.Render(
-            world_->GetStateManager()->GetState(), *client_state_, frame_percent, last_fps);
+          scene.Render(*world_->GetStateManager(), *client_state_, frame_percent, last_fps);
 
           window_->SwapBuffers();
           window_->PollInput();

--- a/source/client/application/Application.cpp
+++ b/source/client/application/Application.cpp
@@ -155,9 +155,9 @@ Application::Application(const std::vector<const char*>& cli_parameters)
     spdlog::debug("{} Map: {}", map_path.empty(), map_path);
 
     if (map_path.empty()) {
-        world_->GetStateManager()->GetState().map.CreateEmptyMap();
+        world_->GetStateManager()->GetMap().CreateEmptyMap();
     } else {
-        world_->GetStateManager()->GetState().map.LoadMap(map_path);
+        world_->GetStateManager()->GetMap().LoadMap(map_path);
     }
 
     if (application_mode_ == CommandLineParameters::ApplicationMode::Online) {
@@ -289,7 +289,7 @@ void Application::Run()
     client_state_->event_respawn_player_at_spawn_point_requested.AddObserver(
       [&](unsigned int spawn_point_id) {
           const auto& spawn_point =
-            world_->GetStateManager()->GetState().map.GetSpawnPoints().at(spawn_point_id);
+            world_->GetStateManager()->GetMap().GetSpawnPoints().at(spawn_point_id);
           glm::vec2 position = { spawn_point.x, spawn_point.y };
           world_->SpawnSoldier(*client_state_->client_soldier_id, position);
       });
@@ -330,14 +330,13 @@ void Application::Run()
         client_state_->draw_game_debug_interface = true;
         client_state_->camera_component.ResetZoom();
         world_->GetStateManager()->GetState().paused = false;
-        if (!world_->GetStateManager()->GetState().map.GetPolygons().empty()) {
-            auto vertex =
-              world_->GetStateManager()->GetState().map.GetPolygons().at(0).vertices.at(0);
+        if (!world_->GetStateManager()->GetMap().GetPolygons().empty()) {
+            auto vertex = world_->GetStateManager()->GetMap().GetPolygons().at(0).vertices.at(0);
             glm::vec2 old_polygon_position = { vertex.x, vertex.y };
 
-            world_->GetStateManager()->GetState().map.GenerateSectors();
+            world_->GetStateManager()->GetMap().GenerateSectors();
 
-            vertex = world_->GetStateManager()->GetState().map.GetPolygons().at(0).vertices.at(0);
+            vertex = world_->GetStateManager()->GetMap().GetPolygons().at(0).vertices.at(0);
             glm::vec2 move_offset = { vertex.x - old_polygon_position.x,
                                       vertex.y - old_polygon_position.y };
 

--- a/source/client/application/Application.cpp
+++ b/source/client/application/Application.cpp
@@ -142,8 +142,7 @@ Application::Application(const std::vector<const char*>& cli_parameters)
         case CommandLineParameters::ApplicationMode::MapEditor: {
             client_state_->draw_map_editor_interface = true;
             client_state_->draw_game_interface = false;
-            map_editor_ =
-              std::make_unique<MapEditor>(*client_state_, world_->GetStateManager()->GetState());
+            map_editor_ = std::make_unique<MapEditor>(*client_state_, *world_->GetStateManager());
             spdlog::info("Application mode = MapEditor");
             break;
         }

--- a/source/client/application/Application.cpp
+++ b/source/client/application/Application.cpp
@@ -307,7 +307,7 @@ void Application::Run()
 
     if (application_mode_ == CommandLineParameters::ApplicationMode::MapEditor) {
         window_->SetCursorMode(CursorMode::Normal);
-        world_->GetStateManager()->GetState().paused = true;
+        world_->GetStateManager()->PauseGame();
     }
 
     client_state_->map_editor_state.event_pressed_play.AddObserver([&]() {
@@ -329,7 +329,7 @@ void Application::Run()
         client_state_->draw_map_editor_interface = false;
         client_state_->draw_game_debug_interface = true;
         client_state_->camera_component.ResetZoom();
-        world_->GetStateManager()->GetState().paused = false;
+        world_->GetStateManager()->UnPauseGame();
         if (!world_->GetStateManager()->GetMap().GetPolygons().empty()) {
             auto vertex = world_->GetStateManager()->GetMap().GetPolygons().at(0).vertices.at(0);
             glm::vec2 old_polygon_position = { vertex.x, vertex.y };
@@ -356,7 +356,7 @@ void Application::Run()
                 client_state_->draw_game_interface = false;
                 client_state_->draw_map_editor_interface = true;
                 client_state_->draw_game_debug_interface = false;
-                world_->GetStateManager()->GetState().paused = true;
+                world_->GetStateManager()->PauseGame();
                 window_->SetCursorMode(CursorMode::Normal);
                 map_editor_->Unlock();
             } else {
@@ -427,11 +427,10 @@ void Application::Run()
             (application_mode_ == CommandLineParameters::ApplicationMode::MapEditor &&
              client_state_->draw_game_interface)) {
             if (Keyboard::KeyWentDown(GLFW_KEY_F10)) {
-                world_->GetStateManager()->GetState().paused =
-                  !world_->GetStateManager()->GetState().paused;
+                world_->GetStateManager()->TogglePauseGame();
             }
 
-            if (world_->GetStateManager()->GetState().paused) {
+            if (world_->GetStateManager()->IsGamePaused()) {
                 glm::vec2 mouse_position = { Mouse::GetX(), Mouse::GetY() };
 
                 client_state_->camera_prev = client_state_->camera;

--- a/source/client/application/Application.cpp
+++ b/source/client/application/Application.cpp
@@ -454,7 +454,7 @@ void Application::Run()
             networking_client_->SetLag(client_state_->network_lag);
             networking_client_->Update(client_network_event_dispatcher_);
 
-            if ((world_->GetStateManager()->GetState().game_tick % 60 == 0)) {
+            if ((world_->GetStateManager()->GetGameTick() % 60 == 0)) {
                 if (client_state_->ping_timer.IsRunning()) {
                     client_state_->ping_timer.Update();
                     if (client_state_->ping_timer.IsOverThreshold()) {
@@ -588,7 +588,7 @@ void Application::Run()
 
                 SoldierInputPacket update_soldier_state_packet{
                     .input_sequence_id = input_sequence_id,
-                    .game_tick = world_->GetStateManager()->GetState().game_tick,
+                    .game_tick = world_->GetStateManager()->GetGameTick(),
                     .position_x = world_->GetSoldier(client_soldier_id).particle.position.x,
                     .position_y = world_->GetSoldier(client_soldier_id).particle.position.y,
                     .mouse_map_position_x = mouse_map_position.x,

--- a/source/client/application/Application.cpp
+++ b/source/client/application/Application.cpp
@@ -312,14 +312,8 @@ void Application::Run()
 
     client_state_->map_editor_state.event_pressed_play.AddObserver([&]() {
         std::uint8_t client_soldier_id = *client_state_->client_soldier_id;
-        bool is_soldier_active = false;
-        bool is_soldier_alive = false;
-        for (const auto& soldier : world_->GetStateManager()->GetState().soldiers) {
-            if (soldier.id == client_soldier_id && soldier.active) {
-                is_soldier_active = true;
-                is_soldier_alive = !soldier.dead_meat;
-            }
-        }
+        bool is_soldier_active = world_->GetStateManager()->GetSoldier(client_soldier_id).active;
+        bool is_soldier_alive = !world_->GetStateManager()->GetSoldier(client_soldier_id).dead_meat;
 
         if (!is_soldier_active || !is_soldier_alive) {
             world_->SpawnSoldier(*client_state_->client_soldier_id);
@@ -341,9 +335,9 @@ void Application::Run()
                                       vertex.y - old_polygon_position.y };
 
             // Move soldiers if the map moved
-            for (const auto& soldier : world_->GetStateManager()->GetState().soldiers) {
+            world_->GetStateManager()->TransformSoldiers([&](auto& soldier) {
                 world_->GetStateManager()->MoveSoldier(soldier.id, move_offset);
-            }
+            });
         }
         window_->SetCursorMode(CursorMode::Locked);
         map_editor_->Lock();
@@ -478,14 +472,10 @@ void Application::Run()
 
         if (client_state_->client_soldier_id.has_value()) {
             std::uint8_t client_soldier_id = *client_state_->client_soldier_id;
-            bool is_soldier_active = false;
-            bool is_soldier_alive = false;
-            for (const auto& soldier : world_->GetStateManager()->GetState().soldiers) {
-                if (soldier.id == client_soldier_id && soldier.active) {
-                    is_soldier_active = true;
-                    is_soldier_alive = !soldier.dead_meat;
-                }
-            }
+            bool is_soldier_active =
+              world_->GetStateManager()->GetSoldier(client_soldier_id).active;
+            bool is_soldier_alive =
+              !world_->GetStateManager()->GetSoldier(client_soldier_id).dead_meat;
 
             if (is_soldier_active) {
                 if (is_soldier_alive) {

--- a/source/client/map_editor/MapEditor.cpp
+++ b/source/client/map_editor/MapEditor.cpp
@@ -187,6 +187,41 @@ MapEditor::MapEditor(ClientState& client_state, State& game_state)
             game_state);
       });
 
+    client_state.map_editor_state.event_save_map.AddObserver(
+      [&game_state](const std::string& map_name) { game_state.map.SaveMap(map_name); });
+    client_state.map_editor_state.event_set_map_name.AddObserver(
+      [&game_state](const std::string& map_name) { game_state.map.SetName(map_name); });
+    client_state.map_editor_state.event_set_map_description.AddObserver(
+      [&game_state](const std::string& description) {
+          game_state.map.SetDescription(description);
+      });
+    client_state.map_editor_state.event_set_map_weather_type.AddObserver(
+      [&game_state](PMSWeatherType weather_type) { game_state.map.SetWeatherType(weather_type); });
+    client_state.map_editor_state.event_set_map_step_type.AddObserver(
+      [&game_state](PMSStepType step_type) { game_state.map.SetStepType(step_type); });
+    client_state.map_editor_state.event_set_map_grenades_count.AddObserver(
+      [&game_state](unsigned char grenades_count) {
+          game_state.map.SetGrenadesCount(grenades_count);
+      });
+    client_state.map_editor_state.event_set_map_medikits_count.AddObserver(
+      [&game_state](unsigned char medikits_count) {
+          game_state.map.SetMedikitsCount(medikits_count);
+      });
+    client_state.map_editor_state.event_set_map_jet_count.AddObserver(
+      [&game_state](int jet_count) { game_state.map.SetJetCount(jet_count); });
+    client_state.map_editor_state.event_set_map_background_top_color.AddObserver(
+      [&game_state](const PMSColor& background_top_color) {
+          game_state.map.SetBackgroundTopColor(background_top_color);
+      });
+    client_state.map_editor_state.event_set_map_background_bottom_color.AddObserver(
+      [&game_state](const PMSColor& background_bottom_color) {
+          game_state.map.SetBackgroundBottomColor(background_bottom_color);
+      });
+    client_state.map_editor_state.event_set_map_texture_name.AddObserver(
+      [&game_state](const std::string& texture_name) {
+          game_state.map.SetTextureName(texture_name);
+      });
+
     OnSelectNewTool(client_state.map_editor_state.selected_tool, client_state, game_state);
 }
 

--- a/source/client/map_editor/MapEditor.hpp
+++ b/source/client/map_editor/MapEditor.hpp
@@ -8,7 +8,7 @@
 
 #include "rendering/ClientState.hpp"
 
-#include "core/state/State.hpp"
+#include "core/state/StateManager.hpp"
 #include "core/math/Glm.hpp"
 
 #include <deque>
@@ -21,7 +21,7 @@ namespace Soldank
 class MapEditor
 {
 public:
-    MapEditor(ClientState& client_state, State& game_state);
+    MapEditor(ClientState& client_state, StateManager& game_state_manager);
 
     void Lock();
     void Unlock();
@@ -29,9 +29,13 @@ public:
 private:
     static const int ACTION_HISTORY_LIMIT = 50;
 
-    void OnSelectNewTool(ToolType tool_type, ClientState& client_state, const State& game_state);
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state);
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state);
+    void OnSelectNewTool(ToolType tool_type,
+                         ClientState& client_state,
+                         const StateManager& game_state_manager);
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager);
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager);
     void OnSceneRightMouseButtonClick(ClientState& client_state);
     void OnSceneRightMouseButtonRelease();
     void OnSceneMiddleMouseButtonClick(ClientState& client_state);
@@ -44,30 +48,30 @@ private:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state);
+                                  const StateManager& game_state_manager);
 
-    void OnKeyPressed(int key, ClientState& client_state, State& game_state);
+    void OnKeyPressed(int key, ClientState& client_state, StateManager& game_state_manager);
     void OnKeyReleased(int key, ClientState& client_state);
 
     void ExecuteNewAction(ClientState& client_state,
-                          State& game_state,
+                          StateManager& game_state_manager,
                           std::unique_ptr<MapEditorAction> new_action);
-    void UndoLastAction(ClientState& client_state, State& game_state);
-    void RedoUndoneAction(ClientState& client_state, State& game_state);
+    void UndoLastAction(ClientState& client_state, StateManager& game_state_manager);
+    void RedoUndoneAction(ClientState& client_state, StateManager& game_state_manager);
     void UpdateUndoRedoButtons(ClientState& client_state);
 
-    void RemoveCurrentSelection(ClientState& client_state, State& game_state);
+    void RemoveCurrentSelection(ClientState& client_state, StateManager& game_state_manager);
 
     void OnChangeSelectedSpawnPointsTypes(PMSSpawnPointType new_spawn_point_type,
                                           ClientState& client_state,
-                                          State& game_state);
+                                          StateManager& game_state_manager);
     void OnChangeSelectedSceneriesLevel(int new_level,
                                         ClientState& client_state,
-                                        State& game_state);
+                                        StateManager& game_state_manager);
     void OnTransformSelectedPolygons(
       const std::function<PMSPolygon(const PMSPolygon&)>& transform_function,
       ClientState& client_state,
-      State& game_state);
+      StateManager& game_state_manager);
 
     ToolType selected_tool_;
     std::vector<std::unique_ptr<Tool>> tools_;

--- a/source/client/map_editor/actions/AddObjectsMapEditorAction.cpp
+++ b/source/client/map_editor/actions/AddObjectsMapEditorAction.cpp
@@ -25,18 +25,19 @@ AddObjectsMapEditorAction::AddObjectsMapEditorAction(
 }
 
 bool AddObjectsMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                           const State& game_state)
+                                           const StateManager& game_state_manager)
 {
-    if (copied_polygons_.size() + game_state.map.GetPolygonsCount() > MAX_POLYGONS_COUNT) {
+    if (copied_polygons_.size() + game_state_manager.GetConstMap().GetPolygonsCount() >
+        MAX_POLYGONS_COUNT) {
         return false;
     }
 
-    if (copied_sceneries_.size() + game_state.map.GetSceneryInstances().size() >
+    if (copied_sceneries_.size() + game_state_manager.GetConstMap().GetSceneryInstances().size() >
         MAX_SCENERIES_COUNT) {
         return false;
     }
 
-    if (copied_spawn_points_.size() + game_state.map.GetSpawnPoints().size() >
+    if (copied_spawn_points_.size() + game_state_manager.GetConstMap().GetSpawnPoints().size() >
         MAX_SPAWN_POINTS_COUNT) {
         return false;
     }
@@ -44,17 +45,19 @@ bool AddObjectsMapEditorAction::CanExecute(const ClientState& /*client_state*/,
     return true;
 }
 
-void AddObjectsMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void AddObjectsMapEditorAction::Execute(ClientState& /*client_state*/,
+                                        StateManager& game_state_manager)
 {
-    game_state.map.AddPolygons(copied_polygons_);
-    game_state.map.AddSceneries(copied_sceneries_);
-    game_state.map.AddSpawnPoints(copied_spawn_points_);
+    game_state_manager.GetMap().AddPolygons(copied_polygons_);
+    game_state_manager.GetMap().AddSceneries(copied_sceneries_);
+    game_state_manager.GetMap().AddSpawnPoints(copied_spawn_points_);
 }
 
-void AddObjectsMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void AddObjectsMapEditorAction::Undo(ClientState& /*client_state*/,
+                                     StateManager& game_state_manager)
 {
-    game_state.map.RemovePolygonsById(polygon_ids_to_remove_);
-    game_state.map.RemoveSpawnPointsById(spawn_point_ids_to_remove_);
-    game_state.map.RemoveSceneriesById(scenery_ids_to_remove_);
+    game_state_manager.GetMap().RemovePolygonsById(polygon_ids_to_remove_);
+    game_state_manager.GetMap().RemoveSpawnPointsById(spawn_point_ids_to_remove_);
+    game_state_manager.GetMap().RemoveSceneriesById(scenery_ids_to_remove_);
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/AddObjectsMapEditorAction.hpp
+++ b/source/client/map_editor/actions/AddObjectsMapEditorAction.hpp
@@ -16,9 +16,9 @@ public:
         copied_sceneries,
       const std::vector<std::pair<unsigned int, PMSSpawnPoint>>& copied_spawn_points);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     std::vector<PMSPolygon> copied_polygons_;

--- a/source/client/map_editor/actions/AddPolygonMapEditorAction.cpp
+++ b/source/client/map_editor/actions/AddPolygonMapEditorAction.cpp
@@ -8,19 +8,20 @@ AddPolygonMapEditorAction::AddPolygonMapEditorAction(const PMSPolygon& new_polyg
 }
 
 bool AddPolygonMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                           const State& game_state)
+                                           const StateManager& game_state_manager)
 {
-    return game_state.map.GetPolygonsCount() + 1 <= MAX_POLYGONS_COUNT;
+    return game_state_manager.GetConstMap().GetPolygonsCount() + 1 <= MAX_POLYGONS_COUNT;
 }
 
-void AddPolygonMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void AddPolygonMapEditorAction::Execute(ClientState& /*client_state*/,
+                                        StateManager& game_state_manager)
 {
-    added_polygon_ = game_state.map.AddNewPolygon(added_polygon_);
+    added_polygon_ = game_state_manager.GetMap().AddNewPolygon(added_polygon_);
 }
 
-void AddPolygonMapEditorAction::Undo(ClientState& client_state, State& game_state)
+void AddPolygonMapEditorAction::Undo(ClientState& client_state, StateManager& game_state_manager)
 {
-    game_state.map.RemovePolygonById(added_polygon_.id);
+    game_state_manager.GetMap().RemovePolygonById(added_polygon_.id);
     for (unsigned int i = 0; i < client_state.map_editor_state.selected_polygon_vertices.size();
          ++i) {
         if (client_state.map_editor_state.selected_polygon_vertices.at(i).first ==

--- a/source/client/map_editor/actions/AddPolygonMapEditorAction.hpp
+++ b/source/client/map_editor/actions/AddPolygonMapEditorAction.hpp
@@ -12,9 +12,9 @@ class AddPolygonMapEditorAction final : public MapEditorAction
 public:
     AddPolygonMapEditorAction(const PMSPolygon& new_polygon);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     PMSPolygon added_polygon_;

--- a/source/client/map_editor/actions/AddSceneryMapEditorAction.cpp
+++ b/source/client/map_editor/actions/AddSceneryMapEditorAction.cpp
@@ -12,21 +12,23 @@ AddSceneryMapEditorAction::AddSceneryMapEditorAction(const PMSScenery& new_scene
 }
 
 bool AddSceneryMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                           const State& game_state)
+                                           const StateManager& game_state_manager)
 {
-    return game_state.map.GetSceneryInstances().size() + 1 <= MAX_SCENERIES_COUNT;
+    return game_state_manager.GetConstMap().GetSceneryInstances().size() + 1 <= MAX_SCENERIES_COUNT;
 
     return true;
 }
 
-void AddSceneryMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void AddSceneryMapEditorAction::Execute(ClientState& /*client_state*/,
+                                        StateManager& game_state_manager)
 {
-    added_scenery_id_ = game_state.map.AddNewScenery(added_scenery_, file_name_);
+    added_scenery_id_ = game_state_manager.GetMap().AddNewScenery(added_scenery_, file_name_);
 }
 
-void AddSceneryMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void AddSceneryMapEditorAction::Undo(ClientState& /*client_state*/,
+                                     StateManager& game_state_manager)
 {
-    added_scenery_ = game_state.map.RemoveSceneryById(added_scenery_id_);
+    added_scenery_ = game_state_manager.GetMap().RemoveSceneryById(added_scenery_id_);
     // TODO: remove from selection when implemented
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/AddSceneryMapEditorAction.hpp
+++ b/source/client/map_editor/actions/AddSceneryMapEditorAction.hpp
@@ -14,9 +14,9 @@ class AddSceneryMapEditorAction final : public MapEditorAction
 public:
     AddSceneryMapEditorAction(const PMSScenery& new_scenery, std::string file_name);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     PMSScenery added_scenery_;

--- a/source/client/map_editor/actions/AddSpawnPointMapEditorAction.cpp
+++ b/source/client/map_editor/actions/AddSpawnPointMapEditorAction.cpp
@@ -10,21 +10,23 @@ AddSpawnPointMapEditorAction::AddSpawnPointMapEditorAction(const PMSSpawnPoint& 
 }
 
 bool AddSpawnPointMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                              const State& game_state)
+                                              const StateManager& game_state_manager)
 {
-    return game_state.map.GetSpawnPoints().size() + 1 <= MAX_SPAWN_POINTS_COUNT;
+    return game_state_manager.GetConstMap().GetSpawnPoints().size() + 1 <= MAX_SPAWN_POINTS_COUNT;
 
     return true;
 }
 
-void AddSpawnPointMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void AddSpawnPointMapEditorAction::Execute(ClientState& /*client_state*/,
+                                           StateManager& game_state_manager)
 {
-    added_spawn_point_id_ = game_state.map.AddNewSpawnPoint(added_spawn_point_);
+    added_spawn_point_id_ = game_state_manager.GetMap().AddNewSpawnPoint(added_spawn_point_);
 }
 
-void AddSpawnPointMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void AddSpawnPointMapEditorAction::Undo(ClientState& /*client_state*/,
+                                        StateManager& game_state_manager)
 {
-    added_spawn_point_ = game_state.map.RemoveSpawnPointById(added_spawn_point_id_);
+    added_spawn_point_ = game_state_manager.GetMap().RemoveSpawnPointById(added_spawn_point_id_);
     // TODO: remove from selection when implemented
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/AddSpawnPointMapEditorAction.hpp
+++ b/source/client/map_editor/actions/AddSpawnPointMapEditorAction.hpp
@@ -12,9 +12,9 @@ class AddSpawnPointMapEditorAction final : public MapEditorAction
 public:
     AddSpawnPointMapEditorAction(const PMSSpawnPoint& new_spawn_point);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     PMSSpawnPoint added_spawn_point_;

--- a/source/client/map_editor/actions/ColorObjectsMapEditorAction.cpp
+++ b/source/client/map_editor/actions/ColorObjectsMapEditorAction.cpp
@@ -14,12 +14,13 @@ ColorObjectsMapEditorAction::ColorObjectsMapEditorAction(
 }
 
 bool ColorObjectsMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                             const State& /*game_state*/)
+                                             const StateManager& /*game_state_manager*/)
 {
     return true;
 }
 
-void ColorObjectsMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void ColorObjectsMapEditorAction::Execute(ClientState& /*client_state*/,
+                                          StateManager& game_state_manager)
 {
     std::vector<std::pair<std::pair<unsigned int, unsigned int>, PMSColor>>
       polygon_vertices_with_new_color;
@@ -28,19 +29,20 @@ void ColorObjectsMapEditorAction::Execute(ClientState& /*client_state*/, State& 
         polygon_vertices_with_new_color.push_back(
           { { polygon_vertex.first, polygon_vertex.second }, new_color_ });
     }
-    game_state.map.SetPolygonVerticesColorById(polygon_vertices_with_new_color);
+    game_state_manager.GetMap().SetPolygonVerticesColorById(polygon_vertices_with_new_color);
 
     std::vector<std::pair<unsigned int, PMSColor>> scenery_ids_with_new_color;
     scenery_ids_with_new_color.reserve(scenery_ids_with_old_color_.size());
     for (const auto& [scenery_id, _] : scenery_ids_with_old_color_) {
         scenery_ids_with_new_color.emplace_back(scenery_id, new_color_);
     }
-    game_state.map.SetSceneriesColorById(scenery_ids_with_new_color);
+    game_state_manager.GetMap().SetSceneriesColorById(scenery_ids_with_new_color);
 }
 
-void ColorObjectsMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void ColorObjectsMapEditorAction::Undo(ClientState& /*client_state*/,
+                                       StateManager& game_state_manager)
 {
-    game_state.map.SetPolygonVerticesColorById(polygon_vertices_with_old_color_);
-    game_state.map.SetSceneriesColorById(scenery_ids_with_old_color_);
+    game_state_manager.GetMap().SetPolygonVerticesColorById(polygon_vertices_with_old_color_);
+    game_state_manager.GetMap().SetSceneriesColorById(scenery_ids_with_old_color_);
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/ColorObjectsMapEditorAction.hpp
+++ b/source/client/map_editor/actions/ColorObjectsMapEditorAction.hpp
@@ -18,9 +18,9 @@ public:
         polygon_vertices_with_old_color,
       const std::vector<std::pair<unsigned int, PMSColor>>& scenery_ids_with_old_color);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     PMSColor new_color_;

--- a/source/client/map_editor/actions/MapEditorAction.hpp
+++ b/source/client/map_editor/actions/MapEditorAction.hpp
@@ -2,7 +2,7 @@
 #define __MAP_EDITOR_ACTION_HPP__
 
 #include "rendering/ClientState.hpp"
-#include "core/state/State.hpp"
+#include "core/state/StateManager.hpp"
 
 namespace Soldank
 {
@@ -10,9 +10,10 @@ class MapEditorAction
 {
 public:
     virtual ~MapEditorAction() = default;
-    virtual bool CanExecute(const ClientState& client_state, const State& game_state) = 0;
-    virtual void Execute(ClientState& client_state, State& game_state) = 0;
-    virtual void Undo(ClientState& client_state, State& game_state) = 0;
+    virtual bool CanExecute(const ClientState& client_state,
+                            const StateManager& game_state_manager) = 0;
+    virtual void Execute(ClientState& client_state, StateManager& game_state_manager) = 0;
+    virtual void Undo(ClientState& client_state, StateManager& game_state_manager) = 0;
 };
 } // namespace Soldank
 

--- a/source/client/map_editor/actions/MoveSelectionMapEditorAction.cpp
+++ b/source/client/map_editor/actions/MoveSelectionMapEditorAction.cpp
@@ -18,7 +18,8 @@ MoveSelectionMapEditorAction::MoveSelectionMapEditorAction(
 {
 }
 
-void MoveSelectionMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void MoveSelectionMapEditorAction::Execute(ClientState& /*client_state*/,
+                                           StateManager& game_state_manager)
 {
     std::vector<std::pair<std::pair<unsigned int, unsigned int>, glm::vec2>>
       polygon_vertices_with_new_position;
@@ -27,14 +28,14 @@ void MoveSelectionMapEditorAction::Execute(ClientState& /*client_state*/, State&
         polygon_vertices_with_new_position.emplace_back(polygon_vertex,
                                                         old_position + move_offset_);
     }
-    game_state.map.MovePolygonVerticesById(polygon_vertices_with_new_position);
+    game_state_manager.GetMap().MovePolygonVerticesById(polygon_vertices_with_new_position);
 
     std::vector<std::pair<unsigned int, glm::vec2>> scenery_ids_with_new_position;
     scenery_ids_with_new_position.reserve(scenery_ids_with_position_.size());
     for (const auto& [scenery_id, old_position] : scenery_ids_with_position_) {
         scenery_ids_with_new_position.emplace_back(scenery_id, old_position + move_offset_);
     }
-    game_state.map.MoveSceneriesById(scenery_ids_with_new_position);
+    game_state_manager.GetMap().MoveSceneriesById(scenery_ids_with_new_position);
 
     std::vector<std::pair<unsigned int, glm::ivec2>> spawn_point_ids_with_new_position;
     glm::ivec2 spawn_points_move_offset = move_offset_;
@@ -43,47 +44,40 @@ void MoveSelectionMapEditorAction::Execute(ClientState& /*client_state*/, State&
         spawn_point_ids_with_new_position.emplace_back(spawn_point_id,
                                                        old_position + spawn_points_move_offset);
     }
-    game_state.map.MoveSpawnPointsById(spawn_point_ids_with_new_position);
+    game_state_manager.GetMap().MoveSpawnPointsById(spawn_point_ids_with_new_position);
 
     // TODO: start using StateManager to avoid looping over all soldiers all the time
     // TODO: StateManager should handle moving and repositioning skeleton parts
     //       and then should notify Observers about the move
     for (const auto& [soldier_id, soldier_position] : original_soldier_positions_) {
-        for (auto& soldier : game_state.soldiers) {
-            if (soldier.id != soldier_id) {
-                continue;
-            }
-
-            glm::vec2 new_soldier_position = soldier_position + move_offset_;
-
+        glm::vec2 new_soldier_position = soldier_position + move_offset_;
+        game_state_manager.TransformSoldier(soldier_id, [new_soldier_position](auto& soldier) {
             soldier.particle.position = new_soldier_position;
             soldier.particle.old_position = new_soldier_position;
             RepositionSoldierSkeletonParts(soldier);
-        }
+        });
     }
 }
 
 bool MoveSelectionMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                              const State& /*game_state*/)
+                                              const StateManager& /*game_state_manager*/)
 {
     return true;
 }
 
-void MoveSelectionMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void MoveSelectionMapEditorAction::Undo(ClientState& /*client_state*/,
+                                        StateManager& game_state_manager)
 {
-    game_state.map.MovePolygonVerticesById(polygon_vertices_with_old_position_);
-    game_state.map.MoveSceneriesById(scenery_ids_with_position_);
-    game_state.map.MoveSpawnPointsById(spawn_point_ids_with_old_position_);
+    game_state_manager.GetMap().MovePolygonVerticesById(polygon_vertices_with_old_position_);
+    game_state_manager.GetMap().MoveSceneriesById(scenery_ids_with_position_);
+    game_state_manager.GetMap().MoveSpawnPointsById(spawn_point_ids_with_old_position_);
     for (const auto& [soldier_id, soldier_position] : original_soldier_positions_) {
-        for (auto& soldier : game_state.soldiers) {
-            if (soldier.id != soldier_id) {
-                continue;
-            }
-
-            soldier.particle.position = soldier_position;
-            soldier.particle.old_position = soldier_position;
+        glm::vec2 soldier_pos = soldier_position;
+        game_state_manager.TransformSoldier(soldier_id, [soldier_pos](auto& soldier) {
+            soldier.particle.position = soldier_pos;
+            soldier.particle.old_position = soldier_pos;
             RepositionSoldierSkeletonParts(soldier);
-        }
+        });
     }
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/MoveSelectionMapEditorAction.hpp
+++ b/source/client/map_editor/actions/MoveSelectionMapEditorAction.hpp
@@ -17,9 +17,9 @@ public:
       const std::vector<std::pair<unsigned int, glm::ivec2>>& spawn_point_ids_with_position,
       const std::vector<std::pair<unsigned int, glm::vec2>>& original_soldier_positions);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
     void SetMoveOffset(const glm::vec2& new_move_offset) { move_offset_ = new_move_offset; }
 

--- a/source/client/map_editor/actions/RemoveSelectionMapEditorAction.cpp
+++ b/source/client/map_editor/actions/RemoveSelectionMapEditorAction.cpp
@@ -3,8 +3,9 @@
 
 namespace Soldank
 {
-RemoveSelectionMapEditorAction::RemoveSelectionMapEditorAction(const ClientState& client_state,
-                                                               const State& game_state)
+RemoveSelectionMapEditorAction::RemoveSelectionMapEditorAction(
+  const ClientState& client_state,
+  const StateManager& game_state_manager)
     : soldier_ids_to_remove_(client_state.map_editor_state.selected_soldier_ids)
 {
     for (const auto& selected_polygon_vertices :
@@ -12,7 +13,7 @@ RemoveSelectionMapEditorAction::RemoveSelectionMapEditorAction(const ClientState
         if (selected_polygon_vertices.second.all()) {
             polygon_ids_to_remove_.push_back(selected_polygon_vertices.first);
             removed_polygons_.push_back(
-              game_state.map.GetPolygons().at(selected_polygon_vertices.first));
+              game_state_manager.GetConstMap().GetPolygons().at(selected_polygon_vertices.first));
         }
     }
 
@@ -21,43 +22,45 @@ RemoveSelectionMapEditorAction::RemoveSelectionMapEditorAction(const ClientState
 
         spawn_point_ids_to_remove_.push_back(selected_spawn_point_id);
         removed_spawn_points_.emplace_back(
-          selected_spawn_point_id, game_state.map.GetSpawnPoints().at(selected_spawn_point_id));
+          selected_spawn_point_id,
+          game_state_manager.GetConstMap().GetSpawnPoints().at(selected_spawn_point_id));
     }
 
     for (unsigned int selected_scenery_id : client_state.map_editor_state.selected_scenery_ids) {
         scenery_ids_to_remove_.push_back(selected_scenery_id);
         std::string scenery_file_name;
-        for (unsigned int i = 0; const auto& scenery_type : game_state.map.GetSceneryTypes()) {
-            if (i == game_state.map.GetSceneryInstances().at(selected_scenery_id).style - 1) {
+        for (unsigned int i = 0;
+             const auto& scenery_type : game_state_manager.GetConstMap().GetSceneryTypes()) {
+            if (i == game_state_manager.GetConstMap()
+                         .GetSceneryInstances()
+                         .at(selected_scenery_id)
+                         .style -
+                       1) {
                 scenery_file_name = scenery_type.name;
             }
             ++i;
         }
         removed_sceneries_.push_back(
           { selected_scenery_id,
-            { game_state.map.GetSceneryInstances().at(selected_scenery_id), scenery_file_name } });
+            { game_state_manager.GetConstMap().GetSceneryInstances().at(selected_scenery_id),
+              scenery_file_name } });
     }
 }
 
 bool RemoveSelectionMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                                const State& /*game_state*/)
+                                                const StateManager& /*game_state_manager*/)
 {
     return true;
 }
 
-void RemoveSelectionMapEditorAction::Execute(ClientState& client_state, State& game_state)
+void RemoveSelectionMapEditorAction::Execute(ClientState& client_state,
+                                             StateManager& game_state_manager)
 {
-    game_state.map.RemovePolygonsById(polygon_ids_to_remove_);
-    game_state.map.RemoveSpawnPointsById(spawn_point_ids_to_remove_);
-    game_state.map.RemoveSceneriesById(scenery_ids_to_remove_);
+    game_state_manager.GetMap().RemovePolygonsById(polygon_ids_to_remove_);
+    game_state_manager.GetMap().RemoveSpawnPointsById(spawn_point_ids_to_remove_);
+    game_state_manager.GetMap().RemoveSceneriesById(scenery_ids_to_remove_);
     for (unsigned int selected_soldier_id : soldier_ids_to_remove_) {
-        for (auto& soldier : game_state.soldiers) {
-            if (soldier.id != selected_soldier_id) {
-                continue;
-            }
-
-            soldier.active = false;
-        }
+        game_state_manager.RemoveSoldier(selected_soldier_id);
     }
 
     client_state.map_editor_state.selected_polygon_vertices.clear();
@@ -66,19 +69,17 @@ void RemoveSelectionMapEditorAction::Execute(ClientState& client_state, State& g
     client_state.map_editor_state.selected_soldier_ids.clear();
 }
 
-void RemoveSelectionMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void RemoveSelectionMapEditorAction::Undo(ClientState& /*client_state*/,
+                                          StateManager& game_state_manager)
 {
-    game_state.map.AddPolygons(removed_polygons_);
-    game_state.map.AddSpawnPoints(removed_spawn_points_);
-    game_state.map.AddSceneries(removed_sceneries_);
+    game_state_manager.GetMap().AddPolygons(removed_polygons_);
+    game_state_manager.GetMap().AddSpawnPoints(removed_spawn_points_);
+    game_state_manager.GetMap().AddSceneries(removed_sceneries_);
     for (unsigned int selected_soldier_id : soldier_ids_to_remove_) {
-        for (auto& soldier : game_state.soldiers) {
-            if (soldier.id != selected_soldier_id) {
-                continue;
-            }
-
+        game_state_manager.TransformSoldier(selected_soldier_id, [&](auto& soldier) {
+            // TODO: in the future there should be a StateManager method that brings Soldier back
             soldier.active = true;
-        }
+        });
     }
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/RemoveSelectionMapEditorAction.hpp
+++ b/source/client/map_editor/actions/RemoveSelectionMapEditorAction.hpp
@@ -10,11 +10,12 @@ namespace Soldank
 class RemoveSelectionMapEditorAction final : public MapEditorAction
 {
 public:
-    RemoveSelectionMapEditorAction(const ClientState& client_state, const State& game_state);
+    RemoveSelectionMapEditorAction(const ClientState& client_state,
+                                   const StateManager& game_state_manager);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     std::vector<unsigned int> polygon_ids_to_remove_;

--- a/source/client/map_editor/actions/RotateSelectionMapEditorAction.hpp
+++ b/source/client/map_editor/actions/RotateSelectionMapEditorAction.hpp
@@ -21,9 +21,9 @@ public:
       const glm::vec2& origin,
       const glm::vec2& reference_position);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
     void SetCurrentMousePosition(const glm::vec2& new_current_mouse_position)
     {

--- a/source/client/map_editor/actions/ScaleSelectionMapEditorAction.cpp
+++ b/source/client/map_editor/actions/ScaleSelectionMapEditorAction.cpp
@@ -36,12 +36,13 @@ ScaleSelectionMapEditorAction::ScaleSelectionMapEditorAction(
 }
 
 bool ScaleSelectionMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                               const State& /*game_state*/)
+                                               const StateManager& /*game_state_manager*/)
 {
     return true;
 }
 
-void ScaleSelectionMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void ScaleSelectionMapEditorAction::Execute(ClientState& /*client_state*/,
+                                            StateManager& game_state_manager)
 {
     glm::vec2 scale_factor;
 
@@ -88,7 +89,7 @@ void ScaleSelectionMapEditorAction::Execute(ClientState& /*client_state*/, State
         }
         new_polygons.emplace_back(polygon_vertices.first, new_polygon);
     }
-    game_state.map.SetPolygonsById(new_polygons);
+    game_state_manager.GetMap().SetPolygonsById(new_polygons);
 
     std::vector<std::pair<unsigned int, PMSScenery>> new_sceneries;
     new_sceneries.reserve(original_sceneries_.size());
@@ -128,7 +129,7 @@ void ScaleSelectionMapEditorAction::Execute(ClientState& /*client_state*/, State
 
         new_sceneries.emplace_back(scenery_id, new_scenery);
     }
-    game_state.map.SetSceneriesById(new_sceneries);
+    game_state_manager.GetMap().SetSceneriesById(new_sceneries);
 
     std::vector<std::pair<unsigned int, PMSSpawnPoint>> new_spawn_points;
     new_spawn_points.reserve(original_spawn_points_.size());
@@ -140,42 +141,34 @@ void ScaleSelectionMapEditorAction::Execute(ClientState& /*client_state*/, State
         new_spawn_point.y = new_position.y;
         new_spawn_points.emplace_back(spawn_point_id, new_spawn_point);
     }
-    game_state.map.SetSpawnPointsById(new_spawn_points);
+    game_state_manager.GetMap().SetSpawnPointsById(new_spawn_points);
 
     // TODO: start using StateManager to avoid looping over all soldiers all the time
     // TODO: StateManager should handle moving and repositioning skeleton parts
     //       and then should notify Observers about the move
     for (const auto& [soldier_id, soldier_position] : original_soldier_positions_) {
-        for (auto& soldier : game_state.soldiers) {
-            if (soldier.id != soldier_id) {
-                continue;
-            }
-
-            glm::vec2 new_soldier_position =
-              Calc::ScalePoint(soldier_position, origin_, scale_factor);
-
+        glm::vec2 new_soldier_position = Calc::ScalePoint(soldier_position, origin_, scale_factor);
+        game_state_manager.TransformSoldier(soldier_id, [new_soldier_position](auto& soldier) {
             soldier.particle.position = new_soldier_position;
             soldier.particle.old_position = new_soldier_position;
             RepositionSoldierSkeletonParts(soldier);
-        }
+        });
     }
 }
 
-void ScaleSelectionMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void ScaleSelectionMapEditorAction::Undo(ClientState& /*client_state*/,
+                                         StateManager& game_state_manager)
 {
-    game_state.map.SetPolygonsById(original_polygons_);
-    game_state.map.SetSceneriesById(original_sceneries_);
-    game_state.map.SetSpawnPointsById(original_spawn_points_);
+    game_state_manager.GetMap().SetPolygonsById(original_polygons_);
+    game_state_manager.GetMap().SetSceneriesById(original_sceneries_);
+    game_state_manager.GetMap().SetSpawnPointsById(original_spawn_points_);
     for (const auto& [soldier_id, soldier_position] : original_soldier_positions_) {
-        for (auto& soldier : game_state.soldiers) {
-            if (soldier.id != soldier_id) {
-                continue;
-            }
-
-            soldier.particle.position = soldier_position;
-            soldier.particle.old_position = soldier_position;
+        glm::vec2 soldier_pos = soldier_position;
+        game_state_manager.TransformSoldier(soldier_id, [soldier_pos](auto& soldier) {
+            soldier.particle.position = soldier_pos;
+            soldier.particle.old_position = soldier_pos;
             RepositionSoldierSkeletonParts(soldier);
-        }
+        });
     }
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/ScaleSelectionMapEditorAction.hpp
+++ b/source/client/map_editor/actions/ScaleSelectionMapEditorAction.hpp
@@ -24,9 +24,9 @@ public:
       bool is_scale_horizontal = true,
       bool is_scale_vertical = true);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
     void SetCurrentMousePosition(const glm::vec2& new_current_mouse_position)
     {

--- a/source/client/map_editor/actions/TransformPolygonsMapEditorAction.cpp
+++ b/source/client/map_editor/actions/TransformPolygonsMapEditorAction.cpp
@@ -12,23 +12,25 @@ TransformPolygonsMapEditorAction::TransformPolygonsMapEditorAction(
 }
 
 bool TransformPolygonsMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                                  const State& /*game_state*/)
+                                                  const StateManager& /*game_state_manager*/)
 {
     return true;
 }
 
-void TransformPolygonsMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void TransformPolygonsMapEditorAction::Execute(ClientState& /*client_state*/,
+                                               StateManager& game_state_manager)
 {
     std::vector<std::pair<unsigned int, PMSPolygon>> new_polygons;
     for (const auto& old_polygon : old_polygons_) {
         PMSPolygon new_polygon = transform_function_(old_polygon.second);
         new_polygons.emplace_back(old_polygon.first, new_polygon);
     }
-    game_state.map.SetPolygonsById(new_polygons);
+    game_state_manager.GetMap().SetPolygonsById(new_polygons);
 }
 
-void TransformPolygonsMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void TransformPolygonsMapEditorAction::Undo(ClientState& /*client_state*/,
+                                            StateManager& game_state_manager)
 {
-    game_state.map.SetPolygonsById(old_polygons_);
+    game_state_manager.GetMap().SetPolygonsById(old_polygons_);
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/TransformPolygonsMapEditorAction.hpp
+++ b/source/client/map_editor/actions/TransformPolygonsMapEditorAction.hpp
@@ -14,9 +14,9 @@ public:
       const std::vector<std::pair<unsigned int, PMSPolygon>>& old_polygons,
       const std::function<PMSPolygon(const PMSPolygon&)>& transform_function);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     std::vector<std::pair<unsigned int, PMSPolygon>> old_polygons_;

--- a/source/client/map_editor/actions/TransformSceneriesMapEditorAction.cpp
+++ b/source/client/map_editor/actions/TransformSceneriesMapEditorAction.cpp
@@ -12,23 +12,25 @@ TransformSceneriesMapEditorAction::TransformSceneriesMapEditorAction(
 }
 
 bool TransformSceneriesMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                                   const State& /*game_state*/)
+                                                   const StateManager& /*game_state_manager*/)
 {
     return true;
 }
 
-void TransformSceneriesMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void TransformSceneriesMapEditorAction::Execute(ClientState& /*client_state*/,
+                                                StateManager& game_state_manager)
 {
     std::vector<std::pair<unsigned int, PMSScenery>> new_sceneries;
     for (const auto& old_scenery : old_sceneries_) {
         PMSScenery new_scenery = transform_function_(old_scenery.second);
         new_sceneries.emplace_back(old_scenery.first, new_scenery);
     }
-    game_state.map.SetSceneriesById(new_sceneries);
+    game_state_manager.GetMap().SetSceneriesById(new_sceneries);
 }
 
-void TransformSceneriesMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void TransformSceneriesMapEditorAction::Undo(ClientState& /*client_state*/,
+                                             StateManager& game_state_manager)
 {
-    game_state.map.SetSceneriesById(old_sceneries_);
+    game_state_manager.GetMap().SetSceneriesById(old_sceneries_);
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/TransformSceneriesMapEditorAction.hpp
+++ b/source/client/map_editor/actions/TransformSceneriesMapEditorAction.hpp
@@ -14,9 +14,9 @@ public:
       const std::vector<std::pair<unsigned int, PMSScenery>>& old_sceneries,
       const std::function<PMSScenery(const PMSScenery&)>& transform_function);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     std::vector<std::pair<unsigned int, PMSScenery>> old_sceneries_;

--- a/source/client/map_editor/actions/TransformSpawnPointsMapEditorAction.cpp
+++ b/source/client/map_editor/actions/TransformSpawnPointsMapEditorAction.cpp
@@ -12,23 +12,25 @@ TransformSpawnPointsMapEditorAction::TransformSpawnPointsMapEditorAction(
 }
 
 bool TransformSpawnPointsMapEditorAction::CanExecute(const ClientState& /*client_state*/,
-                                                     const State& /*game_state*/)
+                                                     const StateManager& /*game_state_manager*/)
 {
     return true;
 }
 
-void TransformSpawnPointsMapEditorAction::Execute(ClientState& /*client_state*/, State& game_state)
+void TransformSpawnPointsMapEditorAction::Execute(ClientState& /*client_state*/,
+                                                  StateManager& game_state_manager)
 {
     std::vector<std::pair<unsigned int, PMSSpawnPoint>> new_spawn_points;
     for (const auto& old_spawn_point : old_spawn_points_) {
         PMSSpawnPoint new_spawn_point = transform_function_(old_spawn_point.second);
         new_spawn_points.emplace_back(old_spawn_point.first, new_spawn_point);
     }
-    game_state.map.SetSpawnPointsById(new_spawn_points);
+    game_state_manager.GetMap().SetSpawnPointsById(new_spawn_points);
 }
 
-void TransformSpawnPointsMapEditorAction::Undo(ClientState& /*client_state*/, State& game_state)
+void TransformSpawnPointsMapEditorAction::Undo(ClientState& /*client_state*/,
+                                               StateManager& game_state_manager)
 {
-    game_state.map.SetSpawnPointsById(old_spawn_points_);
+    game_state_manager.GetMap().SetSpawnPointsById(old_spawn_points_);
 }
 } // namespace Soldank

--- a/source/client/map_editor/actions/TransformSpawnPointsMapEditorAction.hpp
+++ b/source/client/map_editor/actions/TransformSpawnPointsMapEditorAction.hpp
@@ -14,9 +14,9 @@ public:
       const std::vector<std::pair<unsigned int, PMSSpawnPoint>>& old_spawn_points,
       const std::function<PMSSpawnPoint(const PMSSpawnPoint&)>& transform_function);
 
-    bool CanExecute(const ClientState& client_state, const State& game_state) final;
-    void Execute(ClientState& client_state, State& game_state) final;
-    void Undo(ClientState& client_state, State& game_state) final;
+    bool CanExecute(const ClientState& client_state, const StateManager& game_state_manager) final;
+    void Execute(ClientState& client_state, StateManager& game_state_manager) final;
+    void Undo(ClientState& client_state, StateManager& game_state_manager) final;
 
 private:
     std::vector<std::pair<unsigned int, PMSSpawnPoint>> old_spawn_points_;

--- a/source/client/map_editor/tools/ColorPickerTool.cpp
+++ b/source/client/map_editor/tools/ColorPickerTool.cpp
@@ -4,7 +4,8 @@
 
 namespace Soldank
 {
-void ColorPickerTool::OnSelect(ClientState& client_state, const State& /*game_state*/)
+void ColorPickerTool::OnSelect(ClientState& client_state,
+                               const StateManager& /*game_state_manager*/)
 {
     SetColorPickerMode(ColorPickerMode::ClosestObject, client_state);
 }
@@ -12,19 +13,19 @@ void ColorPickerTool::OnSelect(ClientState& client_state, const State& /*game_st
 void ColorPickerTool::OnUnselect(ClientState& /*client_state*/) {}
 
 void ColorPickerTool::OnSceneLeftMouseButtonClick(ClientState& /*client_state*/,
-                                                  const State& /*game_state*/)
+                                                  const StateManager& /*game_state_manager*/)
 {
 }
 
 void ColorPickerTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
-                                                    const State& game_state)
+                                                    const StateManager& game_state_manager)
 {
     float max_square_distance = 40.0F * 40.0F;
 
     switch (color_picker_mode_) {
         case ColorPickerMode::ClosestObject: {
-            for (int i = game_state.map.GetPolygonsCount() - 1; i >= 0; --i) {
-                const auto& polygon = game_state.map.GetPolygons().at(i);
+            for (int i = game_state_manager.GetConstMap().GetPolygonsCount() - 1; i >= 0; --i) {
+                const auto& polygon = game_state_manager.GetConstMap().GetPolygons().at(i);
 
                 if (Map::PointInPoly(client_state.mouse_map_position, polygon)) {
                     for (const auto& vertex : polygon.vertices) {
@@ -45,8 +46,9 @@ void ColorPickerTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
                 }
             }
 
-            for (int i = game_state.map.GetSceneryInstances().size() - 1; i >= 0; --i) {
-                const auto& scenery = game_state.map.GetSceneryInstances().at(i);
+            for (int i = game_state_manager.GetConstMap().GetSceneryInstances().size() - 1; i >= 0;
+                 --i) {
+                const auto& scenery = game_state_manager.GetConstMap().GetSceneryInstances().at(i);
 
                 if (Map::PointInScenery(client_state.mouse_map_position, scenery)) {
                     client_state.map_editor_state.palette_current_color.at(0) =
@@ -90,7 +92,7 @@ void ColorPickerTool::OnMouseScreenPositionChange(ClientState& /*client_state*/,
 void ColorPickerTool::OnMouseMapPositionChange(ClientState& /*client_state*/,
                                                glm::vec2 /*last_mouse_position*/,
                                                glm::vec2 /*new_mouse_position*/,
-                                               const State& /*game_state*/)
+                                               const StateManager& /*game_state_manager*/)
 {
 }
 

--- a/source/client/map_editor/tools/ColorPickerTool.hpp
+++ b/source/client/map_editor/tools/ColorPickerTool.hpp
@@ -11,11 +11,13 @@ public:
     ColorPickerTool() = default;
     ~ColorPickerTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -24,7 +26,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/ColorTool.cpp
+++ b/source/client/map_editor/tools/ColorTool.cpp
@@ -13,14 +13,15 @@ ColorTool::ColorTool(
 {
 }
 
-void ColorTool::OnSelect(ClientState& client_state, const State& game_state)
+void ColorTool::OnSelect(ClientState& client_state, const StateManager& /*game_state_manager*/)
 {
     client_state.map_editor_state.current_tool_action_description = "Color objects";
 }
 
 void ColorTool::OnUnselect(ClientState& client_state) {}
 
-void ColorTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state)
+void ColorTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                            const StateManager& game_state_manager)
 {
     bool is_anything_selected = false;
 
@@ -37,7 +38,8 @@ void ColorTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const Sta
             for (unsigned int i = 0; i < 3; ++i) {
                 if (polygon_vertices.second[i]) {
                     polygon_vertices_to_color.push_back({ { polygon_vertices.first, i },
-                                                          game_state.map.GetPolygons()
+                                                          game_state_manager.GetConstMap()
+                                                            .GetPolygons()
                                                             .at(polygon_vertices.first)
                                                             .vertices.at(i)
                                                             .color });
@@ -46,25 +48,31 @@ void ColorTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const Sta
         }
         for (const auto& scenery_id : client_state.map_editor_state.selected_scenery_ids) {
             scenery_ids_to_color.emplace_back(
-              scenery_id, game_state.map.GetSceneryInstances().at(scenery_id).color);
+              scenery_id,
+              game_state_manager.GetConstMap().GetSceneryInstances().at(scenery_id).color);
         }
     } else {
-        for (unsigned int polygon_id = 0; polygon_id < game_state.map.GetPolygonsCount();
+        for (unsigned int polygon_id = 0;
+             polygon_id < game_state_manager.GetConstMap().GetPolygonsCount();
              ++polygon_id) {
             if (Map::PointInPoly(mouse_map_position_,
-                                 game_state.map.GetPolygons().at(polygon_id))) {
+                                 game_state_manager.GetConstMap().GetPolygons().at(polygon_id))) {
                 for (unsigned int vertex_id = 0; vertex_id < 3; ++vertex_id) {
-                    polygon_vertices_to_color.push_back(
-                      { { polygon_id, vertex_id },
-                        game_state.map.GetPolygons().at(polygon_id).vertices.at(vertex_id).color });
+                    polygon_vertices_to_color.push_back({ { polygon_id, vertex_id },
+                                                          game_state_manager.GetConstMap()
+                                                            .GetPolygons()
+                                                            .at(polygon_id)
+                                                            .vertices.at(vertex_id)
+                                                            .color });
                 }
             }
         }
-        for (unsigned int i = 0; i < game_state.map.GetSceneryInstances().size(); ++i) {
+        for (unsigned int i = 0; i < game_state_manager.GetConstMap().GetSceneryInstances().size();
+             ++i) {
             if (Map::PointInScenery(mouse_map_position_,
-                                    game_state.map.GetSceneryInstances().at(i))) {
-                scenery_ids_to_color.emplace_back(i,
-                                                  game_state.map.GetSceneryInstances().at(i).color);
+                                    game_state_manager.GetConstMap().GetSceneryInstances().at(i))) {
+                scenery_ids_to_color.emplace_back(
+                  i, game_state_manager.GetConstMap().GetSceneryInstances().at(i).color);
             }
         }
     }
@@ -85,7 +93,10 @@ void ColorTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const Sta
     add_new_map_editor_action_(std::move(color_objects_action));
 }
 
-void ColorTool::OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) {}
+void ColorTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                              const StateManager& game_state_manager)
+{
+}
 
 void ColorTool::OnSceneRightMouseButtonClick(ClientState& client_state) {}
 
@@ -100,7 +111,7 @@ void ColorTool::OnMouseScreenPositionChange(ClientState& client_state,
 void ColorTool::OnMouseMapPositionChange(ClientState& /*client_state*/,
                                          glm::vec2 /*last_mouse_position*/,
                                          glm::vec2 new_mouse_position,
-                                         const State& /*game_state*/)
+                                         const StateManager& /*game_state_manager*/)
 {
     mouse_map_position_ = new_mouse_position;
 }

--- a/source/client/map_editor/tools/ColorTool.hpp
+++ b/source/client/map_editor/tools/ColorTool.hpp
@@ -16,11 +16,13 @@ public:
       const std::function<void(std::unique_ptr<MapEditorAction>)>& add_new_map_editor_action);
     ~ColorTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -29,7 +31,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/PolygonTool.cpp
+++ b/source/client/map_editor/tools/PolygonTool.cpp
@@ -15,7 +15,7 @@ PolygonTool::PolygonTool(
 {
 }
 
-void PolygonTool::OnSelect(ClientState& client_state, const State& /*game_state*/)
+void PolygonTool::OnSelect(ClientState& client_state, const StateManager& /*game_state_manager*/)
 {
     client_state.map_editor_state.current_tool_action_description = "Create Polygon";
 }
@@ -27,7 +27,7 @@ void PolygonTool::OnUnselect(ClientState& client_state)
 }
 
 void PolygonTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
-                                              const State& /*game_state*/)
+                                              const StateManager& /*game_state_manager*/)
 {
     if (client_state.map_editor_state.polygon_tool_wip_polygon) {
         client_state.map_editor_state.polygon_tool_wip_polygon->bounciness =
@@ -77,7 +77,7 @@ void PolygonTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
 }
 
 void PolygonTool::OnSceneLeftMouseButtonRelease(ClientState& /*client_state*/,
-                                                const State& /*game_state*/)
+                                                const StateManager& /*game_state_manager*/)
 {
 }
 
@@ -97,13 +97,13 @@ void PolygonTool::OnMouseScreenPositionChange(ClientState& /*client_state*/,
 void PolygonTool::OnMouseMapPositionChange(ClientState& client_state,
                                            glm::vec2 /*last_mouse_position*/,
                                            glm::vec2 new_mouse_position,
-                                           const State& game_state)
+                                           const StateManager& game_state_manager)
 {
     bool alread_snapped = false;
     float closest_distance = SNAP_TO_VERTICES_DISTANCE * SNAP_TO_VERTICES_DISTANCE *
                              client_state.camera_component.GetZoom();
     if (client_state.map_editor_state.is_snap_to_vertices_enabled) {
-        for (const auto& polygon : game_state.map.GetPolygons()) {
+        for (const auto& polygon : game_state_manager.GetConstMap().GetPolygons()) {
             for (const auto& vertex : polygon.vertices) {
                 float square_distance =
                   Calc::SquareDistance(new_mouse_position, { vertex.x, vertex.y });

--- a/source/client/map_editor/tools/PolygonTool.hpp
+++ b/source/client/map_editor/tools/PolygonTool.hpp
@@ -17,11 +17,13 @@ public:
       const std::function<void(std::unique_ptr<MapEditorAction>)>& add_new_map_editor_action);
     ~PolygonTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -30,7 +32,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/SceneryTool.cpp
+++ b/source/client/map_editor/tools/SceneryTool.cpp
@@ -9,7 +9,7 @@ SceneryTool::SceneryTool(
 {
 }
 
-void SceneryTool::OnSelect(ClientState& client_state, const State& game_state)
+void SceneryTool::OnSelect(ClientState& client_state, const StateManager& /*game_state_manager*/)
 {
     client_state.map_editor_state.scenery_to_place.scale_x = 1.0F;
     client_state.map_editor_state.scenery_to_place.scale_y = 1.0F;
@@ -19,7 +19,8 @@ void SceneryTool::OnSelect(ClientState& client_state, const State& game_state)
 
 void SceneryTool::OnUnselect(ClientState& client_state) {}
 
-void SceneryTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state)
+void SceneryTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                              const StateManager& /*game_state_manager*/)
 {
     client_state.map_editor_state.scenery_to_place.color.red =
       (unsigned char)(client_state.map_editor_state.palette_current_color.at(0) * 255.0F);
@@ -38,7 +39,8 @@ void SceneryTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const S
     add_new_map_editor_action_(std::move(add_polygon_action));
 }
 
-void SceneryTool::OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state)
+void SceneryTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                                const StateManager& game_state_manager)
 {
 }
 
@@ -58,7 +60,7 @@ void SceneryTool::OnMouseScreenPositionChange(ClientState& client_state,
 void SceneryTool::OnMouseMapPositionChange(ClientState& client_state,
                                            glm::vec2 /*last_mouse_position*/,
                                            glm::vec2 new_mouse_position,
-                                           const State& /*game_state*/)
+                                           const StateManager& /*game_state_manager*/)
 {
     if (client_state.map_editor_state.is_snap_to_grid_enabled) {
         glm::vec2 snapped_mouse_position = SnapMousePositionToGrid(

--- a/source/client/map_editor/tools/SceneryTool.hpp
+++ b/source/client/map_editor/tools/SceneryTool.hpp
@@ -14,11 +14,13 @@ public:
       const std::function<void(std::unique_ptr<MapEditorAction>)>& add_new_map_editor_action);
     ~SceneryTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -27,7 +29,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/SelectionTool.hpp
+++ b/source/client/map_editor/tools/SelectionTool.hpp
@@ -18,11 +18,13 @@ class SelectionTool final : public Tool
 public:
     ~SelectionTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -31,7 +33,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;
@@ -55,17 +57,23 @@ private:
         Soldier,
     };
 
-    void SelectNextSingleObject(ClientState& client_state, const State& game_state);
+    void SelectNextSingleObject(ClientState& client_state, const StateManager& game_state_manager);
     void SelectNextObject(ClientState& client_state,
-                          const State& game_state,
+                          const StateManager& game_state_manager,
                           unsigned int start_index,
                           NextObjectTypeToSelect next_object_type_to_select);
-    void AddFirstFoundObjectToSelection(ClientState& client_state, const State& game_state);
-    bool AddFirstFoundPolygonToSelection(ClientState& client_state, const State& game_state);
-    bool AddFirstFoundSceneryToSelection(ClientState& client_state, const State& game_state);
-    bool AddFirstFoundSpawnPointToSelection(ClientState& client_state, const State& game_state);
-    bool AddFirstFoundSoldierToSelection(ClientState& client_state, const State& game_state);
-    void RemoveLastFoundObjectFromSelection(ClientState& client_state, const State& game_state);
+    void AddFirstFoundObjectToSelection(ClientState& client_state,
+                                        const StateManager& game_state_manager);
+    bool AddFirstFoundPolygonToSelection(ClientState& client_state,
+                                         const StateManager& game_state_manager);
+    bool AddFirstFoundSceneryToSelection(ClientState& client_state,
+                                         const StateManager& game_state_manager);
+    bool AddFirstFoundSpawnPointToSelection(ClientState& client_state,
+                                            const StateManager& game_state_manager);
+    bool AddFirstFoundSoldierToSelection(ClientState& client_state,
+                                         const StateManager& game_state_manager);
+    void RemoveLastFoundObjectFromSelection(ClientState& client_state,
+                                            const StateManager& game_state_manager);
 
     bool IsMouseInSpawnPoint(const ClientState& client_state,
                              const glm::vec2& spawn_point_position) const;
@@ -73,7 +81,7 @@ private:
     void SetSelectionMode(SelectionMode new_selection_mode, ClientState& client_state);
     static NextObjectTypeToSelect GetNextObjectTypeToSelect(
       NextObjectTypeToSelect current_object_type_to_select,
-      const State& game_state);
+      const StateManager& game_state_manager);
 
     glm::vec2 mouse_map_position_;
 

--- a/source/client/map_editor/tools/SpawnpointTool.cpp
+++ b/source/client/map_editor/tools/SpawnpointTool.cpp
@@ -12,7 +12,7 @@ SpawnpointTool::SpawnpointTool(
 {
 }
 
-void SpawnpointTool::OnSelect(ClientState& client_state, const State& /*game_state*/)
+void SpawnpointTool::OnSelect(ClientState& client_state, const StateManager& /*game_state_manager*/)
 {
     client_state.map_editor_state.spawn_point_preview_position = client_state.mouse_map_position;
     client_state.map_editor_state.current_tool_action_description = "Place Spawn Point";
@@ -21,7 +21,7 @@ void SpawnpointTool::OnSelect(ClientState& client_state, const State& /*game_sta
 void SpawnpointTool::OnUnselect(ClientState& /*client_state*/) {}
 
 void SpawnpointTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
-                                                 const State& /*game_state*/)
+                                                 const StateManager& /*game_state_manager*/)
 {
     PMSSpawnPoint new_spawn_point{
         .active = 1,
@@ -34,7 +34,7 @@ void SpawnpointTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
 }
 
 void SpawnpointTool::OnSceneLeftMouseButtonRelease(ClientState& /*client_state*/,
-                                                   const State& /*game_state*/)
+                                                   const StateManager& /*game_state_manager*/)
 {
 }
 
@@ -54,7 +54,7 @@ void SpawnpointTool::OnMouseScreenPositionChange(ClientState& /*client_state*/,
 void SpawnpointTool::OnMouseMapPositionChange(ClientState& client_state,
                                               glm::vec2 /*last_mouse_position*/,
                                               glm::vec2 new_mouse_position,
-                                              const State& /*game_state*/)
+                                              const StateManager& /*game_state_manager*/)
 {
     if (client_state.map_editor_state.is_snap_to_grid_enabled) {
         client_state.map_editor_state.spawn_point_preview_position = SnapMousePositionToGrid(

--- a/source/client/map_editor/tools/SpawnpointTool.hpp
+++ b/source/client/map_editor/tools/SpawnpointTool.hpp
@@ -15,11 +15,13 @@ public:
       const std::function<void(std::unique_ptr<MapEditorAction>)>& add_new_map_editor_action);
     ~SpawnpointTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -28,7 +30,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/TextureTool.cpp
+++ b/source/client/map_editor/tools/TextureTool.cpp
@@ -2,13 +2,17 @@
 
 namespace Soldank
 {
-void TextureTool::OnSelect(ClientState& client_state, const State& game_state) {}
+void TextureTool::OnSelect(ClientState& client_state, const StateManager& game_state_manager) {}
 
 void TextureTool::OnUnselect(ClientState& client_state) {}
 
-void TextureTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) {}
+void TextureTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                              const StateManager& game_state_manager)
+{
+}
 
-void TextureTool::OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state)
+void TextureTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                                const StateManager& game_state_manager)
 {
 }
 
@@ -25,7 +29,7 @@ void TextureTool::OnMouseScreenPositionChange(ClientState& client_state,
 void TextureTool::OnMouseMapPositionChange(ClientState& client_state,
                                            glm::vec2 last_mouse_position,
                                            glm::vec2 new_mouse_position,
-                                           const State& game_state)
+                                           const StateManager& game_state_manager)
 {
 }
 

--- a/source/client/map_editor/tools/TextureTool.hpp
+++ b/source/client/map_editor/tools/TextureTool.hpp
@@ -11,11 +11,13 @@ public:
     TextureTool() = default;
     ~TextureTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -24,7 +26,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/Tool.hpp
+++ b/source/client/map_editor/tools/Tool.hpp
@@ -2,7 +2,7 @@
 #define __TOOL_HPP__
 
 #include "rendering/ClientState.hpp"
-#include "core/state/State.hpp"
+#include "core/state/StateManager.hpp"
 
 #include "core/math/Glm.hpp"
 
@@ -13,13 +13,13 @@ class Tool
 public:
     virtual ~Tool() = default;
 
-    virtual void OnSelect(ClientState& client_state, const State& game_state) = 0;
+    virtual void OnSelect(ClientState& client_state, const StateManager& game_state_manager) = 0;
     virtual void OnUnselect(ClientState& client_state) = 0;
 
     virtual void OnSceneLeftMouseButtonClick(ClientState& client_state,
-                                             const State& game_state) = 0;
+                                             const StateManager& game_state_manager) = 0;
     virtual void OnSceneLeftMouseButtonRelease(ClientState& client_state,
-                                               const State& game_state) = 0;
+                                               const StateManager& game_state_manager) = 0;
     virtual void OnSceneRightMouseButtonClick(ClientState& client_state) = 0;
     virtual void OnSceneRightMouseButtonRelease() = 0;
     virtual void OnMouseScreenPositionChange(ClientState& client_state,
@@ -28,7 +28,7 @@ public:
     virtual void OnMouseMapPositionChange(ClientState& client_state,
                                           glm::vec2 last_mouse_position,
                                           glm::vec2 new_mouse_position,
-                                          const State& game_state) = 0;
+                                          const StateManager& game_state_manager) = 0;
     virtual void OnModifierKey1Pressed(ClientState& client_state) = 0;
     virtual void OnModifierKey1Released(ClientState& client_state) = 0;
     virtual void OnModifierKey2Pressed(ClientState& client_state) = 0;

--- a/source/client/map_editor/tools/TransformTool.hpp
+++ b/source/client/map_editor/tools/TransformTool.hpp
@@ -21,11 +21,13 @@ public:
       const std::function<void(MapEditorAction*)>& execute_without_adding_map_editor_action);
     ~TransformTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -34,7 +36,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;
@@ -50,7 +52,8 @@ private:
         Rotate
     };
 
-    static void SetupSelectionBox(ClientState& client_state, const State& game_state);
+    static void SetupSelectionBox(ClientState& client_state,
+                                  const StateManager& game_state_manager);
 
     void SetTransformMode(TransformMode new_transform_mode, ClientState& client_state);
 

--- a/source/client/map_editor/tools/VertexColorTool.cpp
+++ b/source/client/map_editor/tools/VertexColorTool.cpp
@@ -2,17 +2,17 @@
 
 namespace Soldank
 {
-void VertexColorTool::OnSelect(ClientState& client_state, const State& game_state) {}
+void VertexColorTool::OnSelect(ClientState& client_state, const StateManager& game_state_manager) {}
 
 void VertexColorTool::OnUnselect(ClientState& client_state) {}
 
 void VertexColorTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
-                                                  const State& game_state)
+                                                  const StateManager& game_state_manager)
 {
 }
 
 void VertexColorTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
-                                                    const State& game_state)
+                                                    const StateManager& game_state_manager)
 {
 }
 
@@ -29,7 +29,7 @@ void VertexColorTool::OnMouseScreenPositionChange(ClientState& client_state,
 void VertexColorTool::OnMouseMapPositionChange(ClientState& client_state,
                                                glm::vec2 last_mouse_position,
                                                glm::vec2 new_mouse_position,
-                                               const State& game_state)
+                                               const StateManager& game_state_manager)
 {
 }
 

--- a/source/client/map_editor/tools/VertexColorTool.hpp
+++ b/source/client/map_editor/tools/VertexColorTool.hpp
@@ -11,11 +11,13 @@ public:
     VertexColorTool() = default;
     ~VertexColorTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -24,7 +26,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/VertexSelectionTool.cpp
+++ b/source/client/map_editor/tools/VertexSelectionTool.cpp
@@ -3,7 +3,10 @@
 
 namespace Soldank
 {
-void VertexSelectionTool::OnSelect(ClientState& client_state, const State& game_state) {}
+void VertexSelectionTool::OnSelect(ClientState& client_state,
+                                   const StateManager& game_state_manager)
+{
+}
 
 void VertexSelectionTool::OnUnselect(ClientState& client_state)
 {
@@ -11,7 +14,7 @@ void VertexSelectionTool::OnUnselect(ClientState& client_state)
 }
 
 void VertexSelectionTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
-                                                      const State& game_state)
+                                                      const StateManager& /*game_state_manager*/)
 {
     client_state.map_editor_state.vertex_selection_box = { { mouse_map_position_ },
                                                            { mouse_map_position_ } };
@@ -19,9 +22,9 @@ void VertexSelectionTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
 }
 
 void VertexSelectionTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
-                                                        const State& game_state)
+                                                        const StateManager& game_state_manager)
 {
-    const Map& map = game_state.map;
+    const Map& map = game_state_manager.GetConstMap();
 
     glm::vec2 selection_start_position = client_state.map_editor_state.vertex_selection_box->first;
     glm::vec2 selection_end_position = client_state.map_editor_state.vertex_selection_box->second;
@@ -65,12 +68,12 @@ void VertexSelectionTool::OnSceneLeftMouseButtonRelease(ClientState& client_stat
     }
 
     client_state.map_editor_state.selected_soldier_ids.clear();
-    for (const auto& soldier : game_state.soldiers) {
+    game_state_manager.ForEachSoldier([&](const auto& soldier) {
         if (soldier.particle.position.x >= left && soldier.particle.position.x <= right &&
             soldier.particle.position.y >= top && soldier.particle.position.y <= bottom) {
             client_state.map_editor_state.selected_soldier_ids.push_back(soldier.id);
         }
-    }
+    });
 
     client_state.map_editor_state.vertex_selection_box = std::nullopt;
 }
@@ -88,7 +91,7 @@ void VertexSelectionTool::OnMouseScreenPositionChange(ClientState& client_state,
 void VertexSelectionTool::OnMouseMapPositionChange(ClientState& client_state,
                                                    glm::vec2 /*last_mouse_position*/,
                                                    glm::vec2 new_mouse_position,
-                                                   const State& /*game_state*/)
+                                                   const StateManager& /*game_state*/)
 {
     mouse_map_position_ = new_mouse_position;
 

--- a/source/client/map_editor/tools/VertexSelectionTool.hpp
+++ b/source/client/map_editor/tools/VertexSelectionTool.hpp
@@ -11,11 +11,13 @@ public:
     VertexSelectionTool() = default;
     ~VertexSelectionTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -24,7 +26,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/map_editor/tools/WaypointTool.cpp
+++ b/source/client/map_editor/tools/WaypointTool.cpp
@@ -2,15 +2,17 @@
 
 namespace Soldank
 {
-void WaypointTool::OnSelect(ClientState& client_state, const State& game_state) {}
+void WaypointTool::OnSelect(ClientState& client_state, const StateManager& game_state_manager) {}
 
 void WaypointTool::OnUnselect(ClientState& client_state) {}
 
-void WaypointTool::OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state)
+void WaypointTool::OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                               const StateManager& game_state_manager)
 {
 }
 
-void WaypointTool::OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state)
+void WaypointTool::OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                                 const StateManager& game_state_manager)
 {
 }
 
@@ -27,7 +29,7 @@ void WaypointTool::OnMouseScreenPositionChange(ClientState& client_state,
 void WaypointTool::OnMouseMapPositionChange(ClientState& client_state,
                                             glm::vec2 last_mouse_position,
                                             glm::vec2 new_mouse_position,
-                                            const State& game_state)
+                                            const StateManager& game_state_manager)
 {
 }
 

--- a/source/client/map_editor/tools/WaypointTool.hpp
+++ b/source/client/map_editor/tools/WaypointTool.hpp
@@ -11,11 +11,13 @@ public:
     WaypointTool() = default;
     ~WaypointTool() final = default;
 
-    void OnSelect(ClientState& client_state, const State& game_state) final;
+    void OnSelect(ClientState& client_state, const StateManager& game_state_manager) final;
     void OnUnselect(ClientState& client_state) final;
 
-    void OnSceneLeftMouseButtonClick(ClientState& client_state, const State& game_state) final;
-    void OnSceneLeftMouseButtonRelease(ClientState& client_state, const State& game_state) final;
+    void OnSceneLeftMouseButtonClick(ClientState& client_state,
+                                     const StateManager& game_state_manager) final;
+    void OnSceneLeftMouseButtonRelease(ClientState& client_state,
+                                       const StateManager& game_state_manager) final;
     void OnSceneRightMouseButtonClick(ClientState& client_state) final;
     void OnSceneRightMouseButtonRelease() final;
     void OnMouseScreenPositionChange(ClientState& client_state,
@@ -24,7 +26,7 @@ public:
     void OnMouseMapPositionChange(ClientState& client_state,
                                   glm::vec2 last_mouse_position,
                                   glm::vec2 new_mouse_position,
-                                  const State& game_state) final;
+                                  const StateManager& game_state_manager) final;
     void OnModifierKey1Pressed(ClientState& client_state) final;
     void OnModifierKey1Released(ClientState& client_state) final;
     void OnModifierKey2Pressed(ClientState& client_state) final;

--- a/source/client/networking/event_handlers/PlayerLeaveNetworkEventHandler.cpp
+++ b/source/client/networking/event_handlers/PlayerLeaveNetworkEventHandler.cpp
@@ -15,14 +15,7 @@ NetworkEventHandlerResult PlayerLeaveNetworkEventHandler::HandleNetworkMessageIm
   unsigned int /*sender_connection_id*/,
   std::uint8_t soldier_id)
 {
-    auto& state = world_->GetStateManager()->GetState();
-    for (auto it = state.soldiers.begin(); it != state.soldiers.end();) {
-        if (it->id == soldier_id) {
-            it = state.soldiers.erase(it);
-        } else {
-            it++;
-        }
-    }
+    world_->GetStateManager()->RemoveSoldier(soldier_id);
 
     return NetworkEventHandlerResult::Success;
 }

--- a/source/client/networking/event_handlers/ProjectileSpawnNetworkEventHandler.cpp
+++ b/source/client/networking/event_handlers/ProjectileSpawnNetworkEventHandler.cpp
@@ -27,7 +27,6 @@ NetworkEventHandlerResult ProjectileSpawnNetworkEventHandler::HandleNetworkMessa
     TeamType team = projectile_spawn_packet.team;
     std::uint8_t owner_id = projectile_spawn_packet.owner_id;
 
-    auto& state = world_->GetStateManager()->GetState();
     BulletParams bullet_params{ style,
                                 weapon,
                                 { position_x, position_y },
@@ -36,7 +35,7 @@ NetworkEventHandlerResult ProjectileSpawnNetworkEventHandler::HandleNetworkMessa
                                 hit_multiply,
                                 team,
                                 owner_id };
-    state.bullets.emplace_back(bullet_params);
+    world_->GetStateManager()->CreateProjectile(bullet_params);
     return NetworkEventHandlerResult::Success;
 }
 } // namespace Soldank

--- a/source/client/networking/event_handlers/SoldierInfoNetworkEventHandler.cpp
+++ b/source/client/networking/event_handlers/SoldierInfoNetworkEventHandler.cpp
@@ -26,11 +26,8 @@ NetworkEventHandlerResult SoldierInfoNetworkEventHandler::HandleNetworkMessageIm
     if (!is_soldier_id_me) {
         spdlog::info("({}) {} has joined the server", soldier_id, player_nick);
         world_->CreateSoldier(soldier_id);
-        for (auto& soldier : world_->GetStateManager()->GetState().soldiers) {
-            if (soldier.id == soldier_id) {
-                soldier.active = true;
-            }
-        }
+        world_->GetStateManager()->TransformSoldier(soldier_id,
+                                                    [](auto& soldier) { soldier.active = true; });
     }
 
     return NetworkEventHandlerResult::Success;

--- a/source/client/networking/event_handlers/SoldierStateNetworkEventHandler.cpp
+++ b/source/client/networking/event_handlers/SoldierStateNetworkEventHandler.cpp
@@ -56,74 +56,71 @@ NetworkEventHandlerResult SoldierStateNetworkEventHandler::HandleNetworkMessageI
     if (is_soldier_id_me) {
         client_state_->soldier_position_server_pov = { soldier_position.x, soldier_position.y };
     }
-    auto& state = world_->GetStateManager()->GetState();
 
-    for (auto& soldier : state.soldiers) {
-        if (soldier.id == soldier_id) {
-            soldier.particle.old_position = soldier_old_position;
-            soldier.particle.position = soldier_position;
-            soldier.body_animation->Exit(soldier, world_->GetPhysicsEvents());
-            soldier.body_animation = world_->GetBodyAnimationState(body_animation_type);
-            soldier.body_animation->Enter(soldier);
-            soldier.body_animation->SetFrame(body_animation_frame);
-            soldier.body_animation->SetSpeed(body_animation_speed);
-            soldier.body_animation->SetCount(body_animation_count);
+    world_->GetStateManager()->TransformSoldier(soldier_id, [&](auto& soldier) {
+        soldier.particle.old_position = soldier_old_position;
+        soldier.particle.position = soldier_position;
+        soldier.body_animation->Exit(soldier, world_->GetPhysicsEvents());
+        soldier.body_animation = world_->GetBodyAnimationState(body_animation_type);
+        soldier.body_animation->Enter(soldier);
+        soldier.body_animation->SetFrame(body_animation_frame);
+        soldier.body_animation->SetSpeed(body_animation_speed);
+        soldier.body_animation->SetCount(body_animation_count);
 
-            soldier.legs_animation->Exit(soldier, world_->GetPhysicsEvents());
-            soldier.legs_animation = world_->GetLegsAnimationState(legs_animation_type);
-            soldier.legs_animation->Enter(soldier);
-            soldier.legs_animation->SetFrame(legs_animation_frame);
-            soldier.legs_animation->SetSpeed(legs_animation_speed);
-            soldier.legs_animation->SetCount(legs_animation_count);
+        soldier.legs_animation->Exit(soldier, world_->GetPhysicsEvents());
+        soldier.legs_animation = world_->GetLegsAnimationState(legs_animation_type);
+        soldier.legs_animation->Enter(soldier);
+        soldier.legs_animation->SetFrame(legs_animation_frame);
+        soldier.legs_animation->SetSpeed(legs_animation_speed);
+        soldier.legs_animation->SetCount(legs_animation_count);
 
-            soldier.particle.SetVelocity(soldier_velocity);
-            soldier.particle.SetForce(soldier_force);
+        soldier.particle.SetVelocity(soldier_velocity);
+        soldier.particle.SetForce(soldier_force);
 
-            soldier.on_ground = on_ground;
-            soldier.on_ground_for_law = on_ground_for_law;
-            soldier.on_ground_last_frame = on_ground_last_frame;
-            soldier.on_ground_permanent = on_ground_permanent;
+        soldier.on_ground = on_ground;
+        soldier.on_ground_for_law = on_ground_for_law;
+        soldier.on_ground_last_frame = on_ground_last_frame;
+        soldier.on_ground_permanent = on_ground_permanent;
 
-            soldier.stance = stance;
+        soldier.stance = stance;
 
-            // TODO: make mouse position not game width and game height dependent
-            soldier.game_width = 640.0;
-            soldier.game_height = 480.0;
-            world_->GetStateManager()->ChangeSoldierMouseMapPosition(
-              soldier_id, { mouse_map_position_x, mouse_map_position_y });
+        // TODO: make mouse position not game width and game height dependent
+        soldier.game_width = 640.0;
+        soldier.game_height = 480.0;
+        world_->GetStateManager()->ChangeSoldierMouseMapPosition(
+          soldier_id, { mouse_map_position_x, mouse_map_position_y });
 
-            if ((float)soldier.control.mouse_aim_x >= soldier.particle.position.x) {
-                soldier.direction = 1;
-            } else {
-                soldier.direction = -1;
-            }
+        if ((float)soldier.control.mouse_aim_x >= soldier.particle.position.x) {
+            soldier.direction = 1;
+        } else {
+            soldier.direction = -1;
+        }
 
-            // TODO: there is a visual bug with feet when another soldier is using jets and going
-            // backwards
-            soldier.control.jets = using_jets;
-            soldier.jets_count = jets_count;
+        // TODO: there is a visual bug with feet when another soldier is using jets and going
+        // backwards
+        soldier.control.jets = using_jets;
+        soldier.jets_count = jets_count;
 
-            soldier.active_weapon = active_weapon;
+        soldier.active_weapon = active_weapon;
 
-            if (!is_soldier_id_me || !client_state_->client_side_prediction) {
-                RepositionSoldierSkeletonParts(soldier);
+        if (!is_soldier_id_me || !client_state_->client_side_prediction) {
+            RepositionSoldierSkeletonParts(soldier);
 
-                // TODO: Figure out if the below section is needed, I have a hunch that it is not
-                if (soldier.dead_meat) {
-                    soldier.skeleton->DoVerletTimestep();
-                    soldier.particle.position = soldier.skeleton->GetPos(12);
-                    // CheckSkeletonOutOfBounds;
-                }
-            }
-            for (auto it = client_state_->soldier_snapshot_history.begin();
-                 it != client_state_->soldier_snapshot_history.end();
-                 ++it) {
-                if (it->first == last_processed_input_id + 1) {
-                    it->second.CompareAndLog(soldier);
-                }
+            // TODO: Figure out if the below section is needed, I have a hunch that it is not
+            if (soldier.dead_meat) {
+                soldier.skeleton->DoVerletTimestep();
+                soldier.particle.position = soldier.skeleton->GetPos(12);
+                // CheckSkeletonOutOfBounds;
             }
         }
-    }
+        for (auto it = client_state_->soldier_snapshot_history.begin();
+             it != client_state_->soldier_snapshot_history.end();
+             ++it) {
+            if (it->first == last_processed_input_id + 1) {
+                it->second.CompareAndLog(soldier);
+            }
+        }
+    });
 
     if (client_state_->server_reconciliation && is_soldier_id_me) {
         for (auto it = client_state_->soldier_snapshot_history.begin();

--- a/source/client/rendering/Scene.cpp
+++ b/source/client/rendering/Scene.cpp
@@ -40,7 +40,10 @@ Scene::Scene(const std::shared_ptr<StateManager>& game_state, ClientState& clien
     SetupImGuiTheme();
 }
 
-void Scene::Render(State& game_state, ClientState& client_state, double frame_percent, int fps)
+void Scene::Render(const State& game_state,
+                   ClientState& client_state,
+                   double frame_percent,
+                   int fps)
 {
     // TODO: handle it better, this is not a good place for this to be
     client_state.current_polygon_texture_dimensions = polygons_renderer_->GetTextureDimensions();

--- a/source/client/rendering/Scene.cpp
+++ b/source/client/rendering/Scene.cpp
@@ -21,12 +21,12 @@
 namespace Soldank
 {
 Scene::Scene(const std::shared_ptr<StateManager>& game_state, ClientState& client_state)
-    : background_renderer_(game_state->GetState().map)
-    , polygons_renderer_(std::make_unique<PolygonsRenderer>(
-        game_state->GetState().map,
-        std::string(game_state->GetState().map.GetTextureName())))
-    , polygon_outlines_renderer_(game_state->GetState().map, { 1.0F, 1.0F, 1.0F, 1.0F })
-    , sceneries_renderer_(game_state->GetState().map)
+    : background_renderer_(game_state->GetMap())
+    , polygons_renderer_(
+        std::make_unique<PolygonsRenderer>(game_state->GetMap(),
+                                           std::string(game_state->GetMap().GetTextureName())))
+    , polygon_outlines_renderer_(game_state->GetMap(), { 1.0F, 1.0F, 1.0F, 1.0F })
+    , sceneries_renderer_(game_state->GetMap())
     , soldier_renderer_(sprite_manager_)
     , cursor_renderer_(client_state)
     , text_renderer_("play-regular.ttf", 48)

--- a/source/client/rendering/Scene.cpp
+++ b/source/client/rendering/Scene.cpp
@@ -32,7 +32,7 @@ Scene::Scene(const std::shared_ptr<StateManager>& game_state, ClientState& clien
     , text_renderer_("play-regular.ttf", 48)
     , bullet_renderer_(sprite_manager_)
     , item_renderer_(sprite_manager_)
-    , map_editor_scene_(client_state, game_state->GetState())
+    , map_editor_scene_(client_state, *game_state)
 {
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);

--- a/source/client/rendering/Scene.cpp
+++ b/source/client/rendering/Scene.cpp
@@ -291,19 +291,16 @@ void Scene::RenderSoldiers(const StateManager& game_state_manager,
             // skip rendering player's soldier sprites now because we will render it later
             return;
         }
-        if (soldier.active) {
-            soldier_renderer_.Render(camera.GetView(), sprite_manager_, soldier, frame_percent);
-        }
+
+        soldier_renderer_.Render(camera.GetView(), sprite_manager_, soldier, frame_percent);
     });
 
     // Render player's soldier last because it's the most important for the player to see their
     // soldier on top of others
     if (client_state.client_soldier_id.has_value()) {
         unsigned int client_soldier_id = *client_state.client_soldier_id;
-        game_state_manager.ForEachSoldier([&](const auto& soldier) {
-            if (soldier.id == client_soldier_id && soldier.active) {
-                soldier_renderer_.Render(camera.GetView(), sprite_manager_, soldier, frame_percent);
-            }
+        game_state_manager.ForSoldier(client_soldier_id, [&](const auto& soldier) {
+            soldier_renderer_.Render(camera.GetView(), sprite_manager_, soldier, frame_percent);
         });
     }
 }

--- a/source/client/rendering/Scene.hpp
+++ b/source/client/rendering/Scene.hpp
@@ -30,7 +30,7 @@ class Scene
 public:
     Scene(const std::shared_ptr<StateManager>& game_state, ClientState& client_state);
 
-    void Render(State& game_state, ClientState& client_state, double frame_percent, int fps);
+    void Render(const State& game_state, ClientState& client_state, double frame_percent, int fps);
 
     void RenderSoldiers(const State& game_state,
                         const ClientState& client_state,

--- a/source/client/rendering/Scene.hpp
+++ b/source/client/rendering/Scene.hpp
@@ -30,9 +30,12 @@ class Scene
 public:
     Scene(const std::shared_ptr<StateManager>& game_state, ClientState& client_state);
 
-    void Render(const State& game_state, ClientState& client_state, double frame_percent, int fps);
+    void Render(const StateManager& game_state_manager,
+                ClientState& client_state,
+                double frame_percent,
+                int fps);
 
-    void RenderSoldiers(const State& game_state,
+    void RenderSoldiers(const StateManager& game_state_manager,
                         const ClientState& client_state,
                         double frame_percent);
 

--- a/source/client/rendering/renderer/BackgroundRenderer.cpp
+++ b/source/client/rendering/renderer/BackgroundRenderer.cpp
@@ -13,7 +13,7 @@ BackgroundRenderer::BackgroundRenderer(Map& map)
 {
     PMSColor background_bottom_color = map.GetBackgroundBottomColor();
     PMSColor background_top_color = map.GetBackgroundTopColor();
-    std::span<float, 4> boundaries = map.GetBoundaries();
+    std::span<const float, 4> boundaries = map.GetBoundaries();
     std::vector<float> vertices;
 
     GenerateGLBufferVertices(background_top_color, background_bottom_color, boundaries, vertices);
@@ -21,8 +21,9 @@ BackgroundRenderer::BackgroundRenderer(Map& map)
     vbo_ = Renderer::CreateVBO(vertices, GL_DYNAMIC_DRAW);
 
     map.GetMapChangeEvents().changed_background_color.AddObserver(
-      [this](
-        const PMSColor& top_color, const PMSColor& bottom_color, std::span<float, 4> boundaries) {
+      [this](const PMSColor& top_color,
+             const PMSColor& bottom_color,
+             std::span<const float, 4> boundaries) {
           OnChangeBackgroundColor(top_color, bottom_color, boundaries);
       });
 }
@@ -42,7 +43,7 @@ void BackgroundRenderer::Render(glm::mat4 transform)
 
 void BackgroundRenderer::OnChangeBackgroundColor(const PMSColor& top_color,
                                                  const PMSColor& bottom_color,
-                                                 std::span<float, 4> boundaries)
+                                                 std::span<const float, 4> boundaries)
 {
     std::vector<float> vertices;
     GenerateGLBufferVertices(top_color, bottom_color, boundaries, vertices);
@@ -51,7 +52,7 @@ void BackgroundRenderer::OnChangeBackgroundColor(const PMSColor& top_color,
 
 void BackgroundRenderer::GenerateGLBufferVertices(PMSColor background_top_color,
                                                   PMSColor background_bottom_color,
-                                                  std::span<float, 4> boundaries,
+                                                  std::span<const float, 4> boundaries,
                                                   std::vector<float>& destination_vertices)
 {
     float bottom_red = (float)background_bottom_color.red / 255.0F;

--- a/source/client/rendering/renderer/BackgroundRenderer.hpp
+++ b/source/client/rendering/renderer/BackgroundRenderer.hpp
@@ -29,10 +29,10 @@ public:
 private:
     void OnChangeBackgroundColor(const PMSColor& top_color,
                                  const PMSColor& bottom_color,
-                                 std::span<float, 4> boundaries);
+                                 std::span<const float, 4> boundaries);
     static void GenerateGLBufferVertices(PMSColor background_top_color,
                                          PMSColor background_bottom_color,
-                                         std::span<float, 4> boundaries,
+                                         std::span<const float, 4> boundaries,
                                          std::vector<float>& destination_vertices);
 
     Shader shader_;

--- a/source/client/rendering/renderer/interface/debug/DebugUI.cpp
+++ b/source/client/rendering/renderer/interface/debug/DebugUI.cpp
@@ -232,7 +232,7 @@ void AddControlActionTypes(const Control& soldier_control,
     }
 }
 
-void Render(State& game_state, ClientState& client_state, double /*frame_percent*/, int fps)
+void Render(const State& game_state, ClientState& client_state, double /*frame_percent*/, int fps)
 {
     ImGuiIO& io = ImGui::GetIO();
     io.AddMousePosEvent(client_state.mouse.x, client_state.window_height - client_state.mouse.y);

--- a/source/client/rendering/renderer/interface/debug/DebugUI.hpp
+++ b/source/client/rendering/renderer/interface/debug/DebugUI.hpp
@@ -6,7 +6,7 @@
 
 namespace Soldank::DebugUI
 {
-void Render(State& game_state, ClientState& client_state, double frame_percent, int fps);
+void Render(const State& game_state, ClientState& client_state, double frame_percent, int fps);
 bool GetWantCaptureMouse();
 } // namespace Soldank::DebugUI
 

--- a/source/client/rendering/renderer/interface/debug/DebugUI.hpp
+++ b/source/client/rendering/renderer/interface/debug/DebugUI.hpp
@@ -6,7 +6,10 @@
 
 namespace Soldank::DebugUI
 {
-void Render(const State& game_state, ClientState& client_state, double frame_percent, int fps);
+void Render(const StateManager& game_state_manager,
+            ClientState& client_state,
+            double frame_percent,
+            int fps);
 bool GetWantCaptureMouse();
 } // namespace Soldank::DebugUI
 

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorScene.cpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorScene.cpp
@@ -9,9 +9,11 @@
 
 namespace Soldank
 {
-MapEditorScene::MapEditorScene(ClientState& client_state, State& game_state)
-    : polygon_vertex_outlines_renderer_(client_state, game_state.map, { 1.0F, 0.0F, 0.0F, 0.5F })
-    , scenery_outlines_renderer_(game_state.map, { 1.0F, 0.0F, 0.0F, 0.5F })
+MapEditorScene::MapEditorScene(ClientState& client_state, StateManager& game_state_manager)
+    : polygon_vertex_outlines_renderer_(client_state,
+                                        game_state_manager.GetMap(),
+                                        { 1.0F, 0.0F, 0.0F, 0.5F })
+    , scenery_outlines_renderer_(game_state_manager.GetMap(), { 1.0F, 0.0F, 0.0F, 0.5F })
 {
     client_state.map_editor_state.map_description_input.reserve(DESCRIPTION_MAX_LENGTH);
     client_state.map_editor_state.event_scenery_texture_changed.AddObserver(

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorScene.cpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorScene.cpp
@@ -18,7 +18,7 @@ MapEditorScene::MapEditorScene(ClientState& client_state, State& game_state)
       [this](const std::string& file_name) { single_image_renderer_.SetTexture(file_name); });
 }
 
-void MapEditorScene::Render(const State& game_state,
+void MapEditorScene::Render(const StateManager& game_state_manager,
                             ClientState& client_state,
                             const PolygonsRenderer& polygons_renderer)
 {
@@ -43,7 +43,7 @@ void MapEditorScene::Render(const State& game_state,
     polygon_vertex_outlines_renderer_.Render(camera.GetView());
 
     if (client_state.map_editor_state.draw_spawn_points) {
-        for (const auto& spawn_point : game_state.map.GetSpawnPoints()) {
+        for (const auto& spawn_point : game_state_manager.GetConstMap().GetSpawnPoints()) {
             spawn_point_renderer_.Render(camera.GetView(), spawn_point, camera.GetZoom());
         }
     }
@@ -51,7 +51,8 @@ void MapEditorScene::Render(const State& game_state,
     for (const auto& selected_spawn_point_id :
          client_state.map_editor_state.selected_spawn_point_ids) {
 
-        const auto& spawn_point = game_state.map.GetSpawnPoints().at(selected_spawn_point_id);
+        const auto& spawn_point =
+          game_state_manager.GetConstMap().GetSpawnPoints().at(selected_spawn_point_id);
         glm::vec2 start_position = { (float)spawn_point.x - 9.0F * camera.GetZoom(),
                                      (float)spawn_point.y - 9.0F * camera.GetZoom() };
         glm::vec2 end_position = { (float)spawn_point.x + 9.0F * camera.GetZoom(),
@@ -64,9 +65,10 @@ void MapEditorScene::Render(const State& game_state,
     }
 
     for (const auto& selected_soldier_id : client_state.map_editor_state.selected_soldier_ids) {
-        for (const auto& soldier : game_state.soldiers) {
+        game_state_manager.ForEachSoldier([&](const auto& soldier) {
+            // TODO: implement different method to execute the lambda for one soldier
             if (soldier.id != selected_soldier_id) {
-                continue;
+                return;
             }
 
             glm::vec2 start_position = { (float)soldier.particle.position.x - 9.0F,
@@ -78,7 +80,7 @@ void MapEditorScene::Render(const State& game_state,
                             end_position,
                             { 0.8F, 0.2F, 0.2F, 0.7F },
                             camera.GetZoom());
-        }
+        });
     }
 
     if (client_state.map_editor_state.selected_tool == ToolType::Spawnpoint) {
@@ -144,7 +146,7 @@ void MapEditorScene::Render(const State& game_state,
           client_state.camera_component.GetZoom());
     }
 
-    MapEditorUI::Render(game_state, client_state);
+    MapEditorUI::Render(game_state_manager, client_state);
 }
 
 void MapEditorScene::RenderRectangle(const glm::mat4& transform,

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorScene.cpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorScene.cpp
@@ -18,7 +18,7 @@ MapEditorScene::MapEditorScene(ClientState& client_state, State& game_state)
       [this](const std::string& file_name) { single_image_renderer_.SetTexture(file_name); });
 }
 
-void MapEditorScene::Render(State& game_state,
+void MapEditorScene::Render(const State& game_state,
                             ClientState& client_state,
                             const PolygonsRenderer& polygons_renderer)
 {

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorScene.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorScene.hpp
@@ -20,7 +20,7 @@ class MapEditorScene
 public:
     MapEditorScene(ClientState& client_state, State& game_state);
 
-    void Render(State& game_state,
+    void Render(const State& game_state,
                 ClientState& client_state,
                 const PolygonsRenderer& polygons_renderer);
 

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorScene.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorScene.hpp
@@ -18,7 +18,7 @@ namespace Soldank
 class MapEditorScene
 {
 public:
-    MapEditorScene(ClientState& client_state, State& game_state);
+    MapEditorScene(ClientState& client_state, StateManager& game_state_manager);
 
     void Render(const StateManager& game_state_manager,
                 ClientState& client_state,

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorScene.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorScene.hpp
@@ -20,7 +20,7 @@ class MapEditorScene
 public:
     MapEditorScene(ClientState& client_state, State& game_state);
 
-    void Render(const State& game_state,
+    void Render(const StateManager& game_state_manager,
                 ClientState& client_state,
                 const PolygonsRenderer& polygons_renderer);
 

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorState.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorState.hpp
@@ -62,6 +62,18 @@ struct MapEditorState
     Observable<PMSPolygonType> event_selected_polygons_type_changed;
     Observable<> event_pixel_color_under_cursor_requested;
 
+    Observable<const std::string&> event_save_map;
+    Observable<const std::string&> event_set_map_name;
+    Observable<const std::string&> event_set_map_description;
+    Observable<PMSWeatherType> event_set_map_weather_type;
+    Observable<PMSStepType> event_set_map_step_type;
+    Observable<unsigned char> event_set_map_grenades_count;
+    Observable<unsigned char> event_set_map_medikits_count;
+    Observable<int> event_set_map_jet_count;
+    Observable<const PMSColor&> event_set_map_background_top_color;
+    Observable<const PMSColor&> event_set_map_background_bottom_color;
+    Observable<const std::string&> event_set_map_texture_name;
+
     // If specified, we render first edge of the polygon
     // that is being created with the polygon tool
     std::optional<PMSPolygon> polygon_tool_wip_polygon_edge;

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.cpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.cpp
@@ -20,7 +20,7 @@ enum class ToolDetailsSubWindowOpenType
     Soldiers
 };
 
-void RenderPolygonToolDetails(State& game_state, ClientState& client_state)
+void RenderPolygonToolDetails(const State& game_state, ClientState& client_state)
 {
     unsigned short new_polygon_id = game_state.map.GetPolygonsCount() + 1;
 
@@ -141,7 +141,7 @@ void RenderPolygonToolDetails(State& game_state, ClientState& client_state)
     }
 }
 
-void RenderSelectionToolDetails(State& game_state, ClientState& client_state)
+void RenderSelectionToolDetails(const State& game_state, ClientState& client_state)
 {
     static ToolDetailsSubWindowOpenType sub_window_open_type = ToolDetailsSubWindowOpenType::None;
 
@@ -422,7 +422,7 @@ void RenderSelectionToolDetails(State& game_state, ClientState& client_state)
     }
 }
 
-void RenderSceneryToolDetails(State& game_state, ClientState& client_state)
+void RenderSceneryToolDetails(const State& game_state, ClientState& client_state)
 {
     unsigned short new_scenery_id = game_state.map.GetSceneryInstances().size() + 1;
     ImGui::Text("Placing scenery: %hu/%d", new_scenery_id, MAX_SCENERIES_COUNT);
@@ -467,7 +467,7 @@ void RenderSceneryToolDetails(State& game_state, ClientState& client_state)
     }
 }
 
-void Render(State& game_state, ClientState& client_state)
+void Render(const State& game_state, ClientState& client_state)
 {
     static ImGuiWindowFlags default_window_flags =
       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.cpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.cpp
@@ -20,9 +20,9 @@ enum class ToolDetailsSubWindowOpenType
     Soldiers
 };
 
-void RenderPolygonToolDetails(const State& game_state, ClientState& client_state)
+void RenderPolygonToolDetails(const StateManager& game_state_manager, ClientState& client_state)
 {
-    unsigned short new_polygon_id = game_state.map.GetPolygonsCount() + 1;
+    unsigned short new_polygon_id = game_state_manager.GetConstMap().GetPolygonsCount() + 1;
 
     ImGui::Text("Placing polygon: %hu/%d", new_polygon_id, MAX_POLYGONS_COUNT);
 
@@ -141,7 +141,7 @@ void RenderPolygonToolDetails(const State& game_state, ClientState& client_state
     }
 }
 
-void RenderSelectionToolDetails(const State& game_state, ClientState& client_state)
+void RenderSelectionToolDetails(const StateManager& game_state_manager, ClientState& client_state)
 {
     static ToolDetailsSubWindowOpenType sub_window_open_type = ToolDetailsSubWindowOpenType::None;
 
@@ -202,7 +202,7 @@ void RenderSelectionToolDetails(const State& game_state, ClientState& client_sta
         sub_window_open_type = ToolDetailsSubWindowOpenType::Polygons;
 
         if (!client_state.map_editor_state.selected_polygon_vertices.empty()) {
-            const auto& polygon = game_state.map.GetPolygons().at(
+            const auto& polygon = game_state_manager.GetConstMap().GetPolygons().at(
               client_state.map_editor_state.selected_polygon_vertices.at(0).first);
 
             static std::vector<std::pair<std::string, PMSPolygonType>> polygon_type_options = {
@@ -255,8 +255,10 @@ void RenderSelectionToolDetails(const State& game_state, ClientState& client_sta
             for (const auto& selected_polygon_vertices :
                  client_state.map_editor_state.selected_polygon_vertices) {
 
-                if (game_state.map.GetPolygons().at(selected_polygon_vertices.first).polygon_type !=
-                    PMSPolygonType::Bouncy) {
+                if (game_state_manager.GetConstMap()
+                      .GetPolygons()
+                      .at(selected_polygon_vertices.first)
+                      .polygon_type != PMSPolygonType::Bouncy) {
                     are_all_selected_bouncy = false;
                 }
             }
@@ -297,9 +299,10 @@ void RenderSelectionToolDetails(const State& game_state, ClientState& client_sta
         sub_window_open_type = ToolDetailsSubWindowOpenType::Sceneries;
 
         if (!client_state.map_editor_state.selected_scenery_ids.empty()) {
-            const auto& scenery = game_state.map.GetSceneryInstances().at(
+            const auto& scenery = game_state_manager.GetConstMap().GetSceneryInstances().at(
               client_state.map_editor_state.selected_scenery_ids.at(0));
-            const auto& scenery_type = game_state.map.GetSceneryTypes().at(scenery.style - 1);
+            const auto& scenery_type =
+              game_state_manager.GetConstMap().GetSceneryTypes().at(scenery.style - 1);
 
             std::string current_level_text;
 
@@ -344,7 +347,8 @@ void RenderSelectionToolDetails(const State& game_state, ClientState& client_sta
         if (!client_state.map_editor_state.selected_spawn_point_ids.empty()) {
             unsigned int selected_spawn_point_id =
               client_state.map_editor_state.selected_spawn_point_ids.at(0);
-            const auto& spawn_point = game_state.map.GetSpawnPoints().at(selected_spawn_point_id);
+            const auto& spawn_point =
+              game_state_manager.GetConstMap().GetSpawnPoints().at(selected_spawn_point_id);
 
             static std::vector<std::pair<std::string, PMSSpawnPointType>> spawn_point_options = {
                 { "Player Spawn", PMSSpawnPointType::General },
@@ -406,9 +410,10 @@ void RenderSelectionToolDetails(const State& game_state, ClientState& client_sta
             unsigned int selected_soldier_id =
               client_state.map_editor_state.selected_soldier_ids.at(0);
 
-            for (const auto& soldier : game_state.soldiers) {
+            game_state_manager.ForEachSoldier([&](const auto& soldier) {
+                // TODO: implement different method to execute the lambda for one soldier
                 if (soldier.id != selected_soldier_id) {
-                    continue;
+                    return;
                 }
 
                 if (ImGui::Button("Respawn player at random spawn")) {
@@ -417,14 +422,15 @@ void RenderSelectionToolDetails(const State& game_state, ClientState& client_sta
 
                 ImGui::Text(
                   "Position: %.2f, %.2f", soldier.particle.position.x, soldier.particle.position.y);
-            }
+            });
         }
     }
 }
 
-void RenderSceneryToolDetails(const State& game_state, ClientState& client_state)
+void RenderSceneryToolDetails(const StateManager& game_state_manager, ClientState& client_state)
 {
-    unsigned short new_scenery_id = game_state.map.GetSceneryInstances().size() + 1;
+    unsigned short new_scenery_id =
+      game_state_manager.GetConstMap().GetSceneryInstances().size() + 1;
     ImGui::Text("Placing scenery: %hu/%d", new_scenery_id, MAX_SCENERIES_COUNT);
     ImGui::Text("Scenery type: %s",
                 client_state.map_editor_state.selected_scenery_to_place.c_str());
@@ -467,7 +473,7 @@ void RenderSceneryToolDetails(const State& game_state, ClientState& client_state
     }
 }
 
-void Render(const State& game_state, ClientState& client_state)
+void Render(const StateManager& game_state_manager, ClientState& client_state)
 {
     static ImGuiWindowFlags default_window_flags =
       ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoResize |
@@ -480,12 +486,12 @@ void Render(const State& game_state, ClientState& client_state)
                 case ToolType::Transform:
                     break;
                 case ToolType::Polygon: {
-                    RenderPolygonToolDetails(game_state, client_state);
+                    RenderPolygonToolDetails(game_state_manager, client_state);
                     break;
                 }
                 case ToolType::VertexSelection:
                 case ToolType::Selection: {
-                    RenderSelectionToolDetails(game_state, client_state);
+                    RenderSelectionToolDetails(game_state_manager, client_state);
                     break;
                 }
                 case ToolType::VertexColor:
@@ -493,7 +499,7 @@ void Render(const State& game_state, ClientState& client_state)
                 case ToolType::Texture:
                     break;
                 case ToolType::Scenery: {
-                    RenderSceneryToolDetails(game_state, client_state);
+                    RenderSceneryToolDetails(game_state_manager, client_state);
                     break;
                 }
                 case ToolType::Waypoint:

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.hpp
@@ -6,7 +6,7 @@
 
 namespace Soldank::MapEditorToolDetailsWindow
 {
-void Render(State& game_state, ClientState& client_state);
+void Render(const State& game_state, ClientState& client_state);
 }
 
 #endif

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorToolDetailsWindow.hpp
@@ -6,7 +6,7 @@
 
 namespace Soldank::MapEditorToolDetailsWindow
 {
-void Render(const State& game_state, ClientState& client_state);
+void Render(const StateManager& game_state_manager, ClientState& client_state);
 }
 
 #endif

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorUI.cpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorUI.cpp
@@ -15,7 +15,7 @@
 
 namespace Soldank::MapEditorUI
 {
-void Render(const State& game_state, ClientState& client_state)
+void Render(const StateManager& game_state_manager, ClientState& client_state)
 {
     ImGuiIO& io = ImGui::GetIO();
     io.AddMousePosEvent(client_state.mouse.x, client_state.mouse.y);
@@ -35,9 +35,9 @@ void Render(const State& game_state, ClientState& client_state)
         if (ImGui::BeginMainMenuBar()) {
             if (ImGui::BeginMenu("File")) {
                 if (ImGui::MenuItem("Save", "CTRL+S")) {
-                    if (game_state.map.GetName()) {
+                    if (game_state_manager.GetConstMap().GetName()) {
                         client_state.map_editor_state.event_save_map.Notify(
-                          "maps/" + *game_state.map.GetName());
+                          "maps/" + *game_state_manager.GetConstMap().GetName());
                         client_state.map_editor_state.is_map_changed = false;
                     } else {
                         client_state.map_editor_state.should_open_save_as_modal = true;
@@ -121,9 +121,9 @@ void Render(const State& game_state, ClientState& client_state)
         if (client_state.map_editor_state.should_open_save_as_modal) {
             client_state.map_editor_state.should_open_save_as_modal = false;
             new_map_name_input.fill(0);
-            if (game_state.map.GetName()) {
+            if (game_state_manager.GetConstMap().GetName()) {
                 unsigned int i = 0;
-                for (char c : *game_state.map.GetName()) {
+                for (char c : *game_state_manager.GetConstMap().GetName()) {
                     new_map_name_input.at(i) = c;
                     ++i;
                 }
@@ -203,7 +203,8 @@ void Render(const State& game_state, ClientState& client_state)
 
             static std::string drag_int_tooltip =
               "Drag left or right to change.\n\nDouble-click to input text manually.";
-            client_state.map_editor_state.map_description_input = game_state.map.GetDescription();
+            client_state.map_editor_state.map_description_input =
+              game_state_manager.GetConstMap().GetDescription();
             client_state.map_editor_state.map_description_input += (char)0;
             ImGui::SeparatorText("Description");
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
@@ -230,11 +231,12 @@ void Render(const State& game_state, ClientState& client_state)
                     { "Snow", PMSWeatherType::Snow },
                 };
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-                if (ImGui::BeginCombo("##WeatherInput",
-                                      game_state.map.GetWeatherTypeText().c_str())) {
+                if (ImGui::BeginCombo(
+                      "##WeatherInput",
+                      game_state_manager.GetConstMap().GetWeatherTypeText().c_str())) {
                     for (const auto& weather_option : weather_options) {
                         if (ImGui::Selectable(weather_option.first.c_str(),
-                                              game_state.map.GetWeatherType() ==
+                                              game_state_manager.GetConstMap().GetWeatherType() ==
                                                 weather_option.second)) {
                             client_state.map_editor_state.event_set_map_weather_type.Notify(
                               weather_option.second);
@@ -251,10 +253,12 @@ void Render(const State& game_state, ClientState& client_state)
                     { "None", PMSStepType::None },
                 };
                 // ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
-                if (ImGui::BeginCombo("##StepsInput", game_state.map.GetStepTypeText().c_str())) {
+                if (ImGui::BeginCombo("##StepsInput",
+                                      game_state_manager.GetConstMap().GetStepTypeText().c_str())) {
                     for (const auto& step_option : step_options) {
                         if (ImGui::Selectable(step_option.first.c_str(),
-                                              game_state.map.GetStepType() == step_option.second)) {
+                                              game_state_manager.GetConstMap().GetStepType() ==
+                                                step_option.second)) {
                             client_state.map_editor_state.event_set_map_step_type.Notify(
                               step_option.second);
                         }
@@ -266,7 +270,7 @@ void Render(const State& game_state, ClientState& client_state)
 
             ImGui::Separator();
             float drag_int_width = ImGui::CalcTextSize("Medical kits: 99").x + 50.0F;
-            int grenades_count = game_state.map.GetGrenadesCount();
+            int grenades_count = game_state_manager.GetConstMap().GetGrenadesCount();
             ImGui::SetNextItemWidth(drag_int_width);
             if (ImGui::DragInt("##GrenadesInput", &grenades_count, 0.1F, 0, 12, "Grenades: %d")) {
                 if (grenades_count < 0) {
@@ -281,7 +285,7 @@ void Render(const State& game_state, ClientState& client_state)
 
             ImGui::SameLine();
 
-            int medikits_count = game_state.map.GetMedikitsCount();
+            int medikits_count = game_state_manager.GetConstMap().GetMedikitsCount();
             ImGui::SetNextItemWidth(drag_int_width);
             if (ImGui::DragInt(
                   "##MedikitsInput", &medikits_count, 0.1F, 0, 12, "Medical kits: %d")) {
@@ -337,7 +341,7 @@ void Render(const State& game_state, ClientState& client_state)
                 client_state.map_editor_state.event_set_map_jet_count.Notify(25999);
             }
             ImGui::SetItemTooltip("Value: 25999");
-            int jet_count = game_state.map.GetJetCount();
+            int jet_count = game_state_manager.GetConstMap().GetJetCount();
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
             if (ImGui::DragInt("##JetFuelCustomInput", &jet_count, 1.0F, 0, 25999)) {
                 if (jet_count < 0) {
@@ -365,7 +369,8 @@ void Render(const State& game_state, ClientState& client_state)
                                          ImGui::GetContentRegionAvail().x / 2.0F + 15.0F);
 
                 ImGui::TableSetColumnIndex(0);
-                PMSColor top_background_color = game_state.map.GetBackgroundTopColor();
+                PMSColor top_background_color =
+                  game_state_manager.GetConstMap().GetBackgroundTopColor();
                 ImVec4 im_top_background_color = ImVec4((float)top_background_color.red / 255.0F,
                                                         (float)top_background_color.green / 255.0F,
                                                         (float)top_background_color.blue / 255.0F,
@@ -395,7 +400,8 @@ void Render(const State& game_state, ClientState& client_state)
                     ImGui::EndPopup();
                 }
 
-                PMSColor bottom_background_color = game_state.map.GetBackgroundBottomColor();
+                PMSColor bottom_background_color =
+                  game_state_manager.GetConstMap().GetBackgroundBottomColor();
                 ImVec4 im_bottom_background_color =
                   ImVec4((float)bottom_background_color.red / 255.0F,
                          (float)bottom_background_color.green / 255.0F,
@@ -429,7 +435,7 @@ void Render(const State& game_state, ClientState& client_state)
                 ImGui::TableSetColumnIndex(1);
                 ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
                 if (ImGui::BeginCombo("##TextureComboPicker",
-                                      game_state.map.GetTextureName().c_str())) {
+                                      game_state_manager.GetConstMap().GetTextureName().c_str())) {
 
                     if (ImGui::IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
                         !ImGui::IsAnyItemActive() && !ImGui::IsMouseClicked(0)) {
@@ -443,7 +449,8 @@ void Render(const State& game_state, ClientState& client_state)
                     std::erase(search_filter, 0);
                     ImGui::Separator();
 
-                    std::filesystem::path map_texture_in_png = game_state.map.GetTextureName();
+                    std::filesystem::path map_texture_in_png =
+                      game_state_manager.GetConstMap().GetTextureName();
                     map_texture_in_png.replace_extension(".png");
                     for (const auto& texture_file_name :
                          client_state.map_editor_state.all_textures_in_directory) {
@@ -453,10 +460,11 @@ void Render(const State& game_state, ClientState& client_state)
                             continue;
                         }
 
-                        if (ImGui::Selectable(texture_file_name.c_str(),
-                                              texture_file_name ==
-                                                  game_state.map.GetTextureName() ||
-                                                texture_file_name == map_texture_in_png.string())) {
+                        if (ImGui::Selectable(
+                              texture_file_name.c_str(),
+                              texture_file_name ==
+                                  game_state_manager.GetConstMap().GetTextureName() ||
+                                texture_file_name == map_texture_in_png.string())) {
 
                             client_state.map_editor_state.event_set_map_texture_name.Notify(
                               texture_file_name);
@@ -531,19 +539,25 @@ void Render(const State& game_state, ClientState& client_state)
 
     if (client_state.map_editor_state.is_properties_window_visible) {
         ImGui::Begin("Properties", nullptr, default_window_flags);
-        ImGui::Text("Polygons: %zu/%d", game_state.map.GetPolygons().size(), MAX_POLYGONS_COUNT);
-        ImGui::Text(
-          "Sceneries: %zu/%d", game_state.map.GetSceneryInstances().size(), MAX_SCENERIES_COUNT);
-        ImGui::Text(
-          "Spawns: %zu/%d", game_state.map.GetSpawnPoints().size(), MAX_SPAWN_POINTS_COUNT);
-        ImGui::Text("Colliders: %zu/128", game_state.map.GetColliders().size());
-        ImGui::Text("Waypoints: %zu/500", game_state.map.GetWayPoints().size());
+        ImGui::Text("Polygons: %zu/%d",
+                    game_state_manager.GetConstMap().GetPolygons().size(),
+                    MAX_POLYGONS_COUNT);
+        ImGui::Text("Sceneries: %zu/%d",
+                    game_state_manager.GetConstMap().GetSceneryInstances().size(),
+                    MAX_SCENERIES_COUNT);
+        ImGui::Text("Spawns: %zu/%d",
+                    game_state_manager.GetConstMap().GetSpawnPoints().size(),
+                    MAX_SPAWN_POINTS_COUNT);
+        ImGui::Text("Colliders: %zu/128", game_state_manager.GetConstMap().GetColliders().size());
+        ImGui::Text("Waypoints: %zu/500", game_state_manager.GetConstMap().GetWayPoints().size());
         ImGui::Text("Connections: 0"); // TODO: Add connections of waypoints
         glm::vec2 map_dimensions;
-        map_dimensions.x = game_state.map.GetBoundaries()[Map::MapBoundary::RightBoundary] -
-                           game_state.map.GetBoundaries()[Map::MapBoundary::LeftBoundary];
-        map_dimensions.y = game_state.map.GetBoundaries()[Map::MapBoundary::BottomBoundary] -
-                           game_state.map.GetBoundaries()[Map::MapBoundary::TopBoundary];
+        map_dimensions.x =
+          game_state_manager.GetConstMap().GetBoundaries()[Map::MapBoundary::RightBoundary] -
+          game_state_manager.GetConstMap().GetBoundaries()[Map::MapBoundary::LeftBoundary];
+        map_dimensions.y =
+          game_state_manager.GetConstMap().GetBoundaries()[Map::MapBoundary::BottomBoundary] -
+          game_state_manager.GetConstMap().GetBoundaries()[Map::MapBoundary::TopBoundary];
         ImGui::Text("Dimensions: %.0fx%.0f", map_dimensions.x, map_dimensions.y);
         ImGui::End();
     }
@@ -626,7 +640,7 @@ void Render(const State& game_state, ClientState& client_state)
     }
 
     if (client_state.map_editor_state.is_tool_details_window_visible) {
-        MapEditorToolDetailsWindow::Render(game_state, client_state);
+        MapEditorToolDetailsWindow::Render(game_state_manager, client_state);
     }
 
     {
@@ -653,7 +667,9 @@ void Render(const State& game_state, ClientState& client_state)
                         flags |= ImGuiTabItemFlags_UnsavedDocument;
                     }
                     if (ImGui::BeginTabItem(
-                          game_state.map.GetName().value_or("Untitled").c_str(), nullptr, flags)) {
+                          game_state_manager.GetConstMap().GetName().value_or("Untitled").c_str(),
+                          nullptr,
+                          flags)) {
                         ImGui::EndTabItem();
                     }
                     if (ImGui::BeginTabItem("+", nullptr)) {
@@ -686,7 +702,8 @@ void Render(const State& game_state, ClientState& client_state)
 
         if (ImGui::Begin("StatusBar", nullptr, flags)) {
             if (ImGui::BeginMenuBar()) {
-                ImGui::Text("%s", game_state.map.GetName().value_or("Untitled").c_str());
+                ImGui::Text(
+                  "%s", game_state_manager.GetConstMap().GetName().value_or("Untitled").c_str());
                 ImGui::SameLine(0, viewport->Size.x / 10.0F);
                 ImGui::Text("Zoom: %.0f%%",
                             // TODO: need to invert zoom on camera class level instead of this

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorUI.cpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorUI.cpp
@@ -15,7 +15,7 @@
 
 namespace Soldank::MapEditorUI
 {
-void Render(State& game_state, ClientState& client_state)
+void Render(const State& game_state, ClientState& client_state)
 {
     ImGuiIO& io = ImGui::GetIO();
     io.AddMousePosEvent(client_state.mouse.x, client_state.mouse.y);
@@ -36,7 +36,8 @@ void Render(State& game_state, ClientState& client_state)
             if (ImGui::BeginMenu("File")) {
                 if (ImGui::MenuItem("Save", "CTRL+S")) {
                     if (game_state.map.GetName()) {
-                        game_state.map.SaveMap("maps/" + *game_state.map.GetName());
+                        client_state.map_editor_state.event_save_map.Notify(
+                          "maps/" + *game_state.map.GetName());
                         client_state.map_editor_state.is_map_changed = false;
                     } else {
                         client_state.map_editor_state.should_open_save_as_modal = true;
@@ -161,8 +162,8 @@ void Render(State& game_state, ClientState& client_state)
                     new_map_name += c;
                 }
                 new_map_name += ".pms";
-                game_state.map.SetName(new_map_name);
-                game_state.map.SaveMap("maps/" + new_map_name);
+                client_state.map_editor_state.event_set_map_name.Notify(new_map_name);
+                client_state.map_editor_state.event_save_map.Notify("maps/" + new_map_name);
                 client_state.map_editor_state.is_map_changed = false;
                 ImGui::CloseCurrentPopup();
             }
@@ -209,7 +210,8 @@ void Render(State& game_state, ClientState& client_state)
             if (ImGui::InputText("##DescriptionInput",
                                  client_state.map_editor_state.map_description_input.data(),
                                  DESCRIPTION_MAX_LENGTH)) {
-                game_state.map.SetDescription(client_state.map_editor_state.map_description_input);
+                client_state.map_editor_state.event_set_map_description.Notify(
+                  client_state.map_editor_state.map_description_input);
             }
 
             ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
@@ -234,7 +236,8 @@ void Render(State& game_state, ClientState& client_state)
                         if (ImGui::Selectable(weather_option.first.c_str(),
                                               game_state.map.GetWeatherType() ==
                                                 weather_option.second)) {
-                            game_state.map.SetWeatherType(weather_option.second);
+                            client_state.map_editor_state.event_set_map_weather_type.Notify(
+                              weather_option.second);
                         }
                     }
                     ImGui::EndCombo();
@@ -252,7 +255,8 @@ void Render(State& game_state, ClientState& client_state)
                     for (const auto& step_option : step_options) {
                         if (ImGui::Selectable(step_option.first.c_str(),
                                               game_state.map.GetStepType() == step_option.second)) {
-                            game_state.map.SetStepType(step_option.second);
+                            client_state.map_editor_state.event_set_map_step_type.Notify(
+                              step_option.second);
                         }
                     }
                     ImGui::EndCombo();
@@ -271,7 +275,7 @@ void Render(State& game_state, ClientState& client_state)
                 if (grenades_count > 12) {
                     grenades_count = 12;
                 }
-                game_state.map.SetGrenadesCount(grenades_count);
+                client_state.map_editor_state.event_set_map_grenades_count.Notify(grenades_count);
             }
             ImGui::SetItemTooltip("%s", drag_int_tooltip.c_str());
 
@@ -287,50 +291,50 @@ void Render(State& game_state, ClientState& client_state)
                 if (medikits_count > 12) {
                     medikits_count = 12;
                 }
-                game_state.map.SetMedikitsCount(medikits_count);
+                client_state.map_editor_state.event_set_map_medikits_count.Notify(medikits_count);
             }
             ImGui::SetItemTooltip("%s", drag_int_tooltip.c_str());
 
             ImVec2 jet_fuel_buttons_size(ImGui::GetContentRegionAvail().x / 4.0F - 9.0F, 0);
             ImGui::SeparatorText("Jet fuel:");
             if (ImGui::Button("None##JetFuelInputNone", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(0);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(0);
             }
             ImGui::SetItemTooltip("Value: 0");
             ImGui::SameLine();
             if (ImGui::Button("Minimal##JetFuelInputMinimal", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(12);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(12);
             }
             ImGui::SetItemTooltip("Value: 12");
             ImGui::SameLine();
             if (ImGui::Button("Very Low##JetFuelInputVeryLow", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(45);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(45);
             }
             ImGui::SetItemTooltip("Value: 45");
             ImGui::SameLine();
             if (ImGui::Button("Low##JetFuelInputLow", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(95);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(95);
             }
 
             // new line
             ImGui::SetItemTooltip("Value: 95");
             if (ImGui::Button("Normal##JetFuelInputNormal", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(190);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(190);
             }
             ImGui::SetItemTooltip("Value: 190");
             ImGui::SameLine();
             if (ImGui::Button("High##JetFuelInputHigh", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(320);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(320);
             }
             ImGui::SetItemTooltip("Value: 320");
             ImGui::SameLine();
             if (ImGui::Button("Extreme##JetFuelInputExtreme", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(800);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(800);
             }
             ImGui::SetItemTooltip("Value: 800");
             ImGui::SameLine();
             if (ImGui::Button("Infinite##JetFuelInputInfinite", jet_fuel_buttons_size)) {
-                game_state.map.SetJetCount(25999);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(25999);
             }
             ImGui::SetItemTooltip("Value: 25999");
             int jet_count = game_state.map.GetJetCount();
@@ -342,7 +346,7 @@ void Render(State& game_state, ClientState& client_state)
                 if (jet_count > 25999) {
                     jet_count = 25999;
                 }
-                game_state.map.SetJetCount(jet_count);
+                client_state.map_editor_state.event_set_map_jet_count.Notify(jet_count);
             }
             ImGui::SetItemTooltip("%s", drag_int_tooltip.c_str());
 
@@ -385,7 +389,8 @@ void Render(State& game_state, ClientState& client_state)
                           (unsigned char)(im_top_background_color.z * 255.0F);
                         top_background_color.alpha =
                           (unsigned char)(im_top_background_color.w * 255.0F);
-                        game_state.map.SetBackgroundTopColor(top_background_color);
+                        client_state.map_editor_state.event_set_map_background_top_color.Notify(
+                          top_background_color);
                     }
                     ImGui::EndPopup();
                 }
@@ -415,7 +420,8 @@ void Render(State& game_state, ClientState& client_state)
                           (unsigned char)(im_bottom_background_color.z * 255.0F);
                         bottom_background_color.alpha =
                           (unsigned char)(im_bottom_background_color.w * 255.0F);
-                        game_state.map.SetBackgroundBottomColor(bottom_background_color);
+                        client_state.map_editor_state.event_set_map_background_bottom_color.Notify(
+                          bottom_background_color);
                     }
                     ImGui::EndPopup();
                 }
@@ -452,7 +458,8 @@ void Render(State& game_state, ClientState& client_state)
                                                   game_state.map.GetTextureName() ||
                                                 texture_file_name == map_texture_in_png.string())) {
 
-                            game_state.map.SetTextureName(texture_file_name);
+                            client_state.map_editor_state.event_set_map_texture_name.Notify(
+                              texture_file_name);
                         }
                     }
                     ImGui::EndCombo();

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorUI.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorUI.hpp
@@ -7,7 +7,7 @@
 
 namespace Soldank::MapEditorUI
 {
-void Render(State& game_state, ClientState& client_state);
+void Render(const State& game_state, ClientState& client_state);
 }
 
 #endif

--- a/source/client/rendering/renderer/interface/map_editor/MapEditorUI.hpp
+++ b/source/client/rendering/renderer/interface/map_editor/MapEditorUI.hpp
@@ -7,7 +7,7 @@
 
 namespace Soldank::MapEditorUI
 {
-void Render(const State& game_state, ClientState& client_state);
+void Render(const StateManager& game_state_manager, ClientState& client_state);
 }
 
 #endif

--- a/source/server/application/Application.cpp
+++ b/source/server/application/Application.cpp
@@ -40,7 +40,7 @@ Application::Application()
     : world_(std::make_shared<World>())
     , lobby_client_(std::make_shared<LobbyClient>())
 {
-    world_->GetStateManager()->GetState().map.LoadMap("maps/ctf_Ash.pms");
+    world_->GetStateManager()->GetMap().LoadMap("maps/ctf_Ash.pms");
     spdlog::set_level(spdlog::level::debug);
 
     bool da_script_initialized = InitDaScriptModule();

--- a/source/server/networking/CoreEventsConnectionNotifier.cpp
+++ b/source/server/networking/CoreEventsConnectionNotifier.cpp
@@ -18,7 +18,7 @@ void CoreEventsConnectionNotifier::ObserveAll(IGameServer* game_server,
 void CoreEventsConnectionNotifier::ObserveAllWorldEvents(IGameServer* game_server,
                                                          WorldEvents& world_events)
 {
-    world_events.after_soldier_spawns.AddObserver([game_server](Soldier& soldier) {
+    world_events.after_soldier_spawns.AddObserver([game_server](const Soldier& soldier) {
         game_server->SendNetworkMessageToAll(NetworkMessage(NetworkEvent::SpawnSoldier,
                                                             soldier.id,
                                                             soldier.particle.position.x,

--- a/source/server/networking/GameServer.cpp
+++ b/source/server/networking/GameServer.cpp
@@ -90,17 +90,12 @@ void GameServer::OnSteamNetConnectionStatusChanged(
                                                                     p_info->m_hConn);
                 player_poll_group_->CloseConnection(p_info);
 
-                auto& state = world_->GetStateManager()->GetState();
-                spdlog::info("CLOSING CONNECTION soldiers size before: {}", state.soldiers.size());
-                for (auto it = state.soldiers.begin(); it != state.soldiers.end();) {
-                    if (it->id == soldier_id) {
-                        it = state.soldiers.erase(it);
-                    } else {
-                        it++;
-                    }
-                }
+                spdlog::info("CLOSING CONNECTION soldiers size before: {}",
+                             world_->GetStateManager()->GetSoldiersCount());
+                world_->GetStateManager()->RemoveSoldier(soldier_id);
 
-                spdlog::info("CLOSING CONNECTION soldiers size after: {}", state.soldiers.size());
+                spdlog::info("CLOSING CONNECTION soldiers size after: {}",
+                             world_->GetStateManager()->GetSoldiersCount());
 
                 server_state_->last_processed_input_id.at(soldier_id) = 0;
             }

--- a/source/server/networking/poll_groups/PlayerPollGroup.cpp
+++ b/source/server/networking/poll_groups/PlayerPollGroup.cpp
@@ -70,13 +70,12 @@ void PlayerPollGroup::AcceptConnection(
 
 void PlayerPollGroup::OnAssignConnection(Connection& connection)
 {
-    const auto& state = world_->GetStateManager()->GetState();
-    for (const auto& soldier : state.soldiers) {
+    world_->GetStateManager()->ForEachSoldier([&](const auto& soldier) {
         std::string player_nick =
           GetConnectionSoldierNick(FindConnectionHandleBySoldierId(soldier.id));
         NetworkMessage network_message(NetworkEvent::SoldierInfo, soldier.id, player_nick);
         SendReliableNetworkMessage(connection.connection_handle, network_message);
-    }
+    });
 
     std::uint8_t soldier_id = world_->CreateSoldier().id;
     connection.soldier_id = soldier_id;

--- a/source/shared/core/CoreEventHandler.cpp
+++ b/source/shared/core/CoreEventHandler.cpp
@@ -120,7 +120,7 @@ void CoreEventHandler::ObserveAllPhysicsEvents(IWorld* world)
                 soldier.id,
                 0.0F // TODO: Add push
             };
-            world->GetStateManager()->CreateProjectile(params);
+            world->GetStateManager()->EnqueueNewProjectile(params);
             world->GetStateManager()->ChangeSoldierPrimaryWeapon(soldier.id, WeaponType::NoWeapon);
         } else {
             spdlog::debug("soldier {} throws a weapon", soldier.id);
@@ -158,7 +158,7 @@ void CoreEventHandler::ObserveAllPhysicsEvents(IWorld* world)
         std::vector<BulletParams> bullet_emitter;
         SoldierPhysics::Fire(soldier, bullet_emitter);
         for (auto& bullet_params : bullet_emitter) {
-            world->GetStateManager()->CreateProjectile(bullet_params);
+            world->GetStateManager()->EnqueueNewProjectile(bullet_params);
         }
     });
     world->GetPhysicsEvents().soldier_collides_with_item.AddObserver(

--- a/source/shared/core/CoreEventHandler.cpp
+++ b/source/shared/core/CoreEventHandler.cpp
@@ -66,7 +66,7 @@ void CoreEventHandler::ObserveAll(IWorld* world)
 
 void CoreEventHandler::ObserveAllWorldEvents(IWorld* world)
 {
-    world->GetWorldEvents().after_soldier_spawns.AddObserver([](Soldier& soldier) {
+    world->GetWorldEvents().after_soldier_spawns.AddObserver([](const Soldier& soldier) {
         spdlog::debug("soldier {} spawned at ({}, {})",
                       soldier.id,
                       soldier.particle.position.x,

--- a/source/shared/core/IWorld.hpp
+++ b/source/shared/core/IWorld.hpp
@@ -19,8 +19,8 @@ protected:
     using TShouldStopGameLoopCallback = std::function<bool()>;
     using TPreGameLoopIterationCallback = std::function<void()>;
     using TPreWorldUpdateCallback = std::function<void()>;
-    using TPostWorldUpdateCallback = std::function<void(const State& state)>;
-    using TPostGameLoopIterationCallback = std::function<void(const State&, double, int)>;
+    using TPostWorldUpdateCallback = std::function<void(const StateManager& state)>;
+    using TPostGameLoopIterationCallback = std::function<void(const StateManager&, double, int)>;
 
     using TPreSoldierUpdateCallback = std::function<bool(const Soldier&)>;
     using TPreProjectileSpawnCallback = std::function<bool(const BulletParams&)>;

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -202,7 +202,7 @@ void World::Update(double /*delta_time*/)
 
     for (auto& bullet : state_manager_->GetState().bullets) {
         BulletPhysics::UpdateBullet(
-          *physics_events_, bullet, state_manager_->GetState().map, state_manager_->GetState());
+          *physics_events_, bullet, state_manager_->GetMap(), state_manager_->GetState());
     }
 
     for (const auto& bullet_params : state_manager_->GetBulletEmitter()) {
@@ -381,7 +381,7 @@ glm::vec2 World::SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> 
         initial_player_position = *spawn_position;
     } else {
         std::vector<glm::vec2> possible_spawn_point_positions;
-        for (const auto& spawn_point : state_manager_->GetState().map.GetSpawnPoints()) {
+        for (const auto& spawn_point : state_manager_->GetMap().GetSpawnPoints()) {
             if (spawn_point.type == PMSSpawnPointType::General ||
                 spawn_point.type == PMSSpawnPointType::Alpha ||
                 spawn_point.type == PMSSpawnPointType::Bravo ||
@@ -393,7 +393,7 @@ glm::vec2 World::SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> 
         }
 
         if (possible_spawn_point_positions.empty()) {
-            for (const auto& spawn_point : state_manager_->GetState().map.GetSpawnPoints()) {
+            for (const auto& spawn_point : state_manager_->GetMap().GetSpawnPoints()) {
                 possible_spawn_point_positions.emplace_back(spawn_point.x, spawn_point.y);
             }
         }

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -171,9 +171,7 @@ void World::Update(double /*delta_time*/)
     state_manager_->GetState().bullets.erase(removed_bullets_range.begin(),
                                              removed_bullets_range.end());
 
-    auto removed_items_range = std::ranges::remove_if(
-      state_manager_->GetState().items, [](const Item& item) { return !item.active; });
-    state_manager_->GetState().items.erase(removed_items_range.begin(), removed_items_range.end());
+    state_manager_->RemoveInactiveItems();
 
     std::vector<BulletParams> bullet_emitter;
 
@@ -216,9 +214,8 @@ void World::Update(double /*delta_time*/)
         }
     }
 
-    for (auto& item : state_manager_->GetState().items) {
-        ItemPhysics::Update(state_manager_->GetState(), item, *physics_events_);
-    }
+    state_manager_->TransformItems(
+      [&](auto& item) { ItemPhysics::Update(state_manager_->GetState(), item, *physics_events_); });
 
     state_manager_->ClearBulletEmitter();
 }

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -54,7 +54,6 @@ World::World()
     : state_manager_(std::make_shared<StateManager>())
     , physics_events_(std::make_unique<PhysicsEvents>())
     , world_events_(std::make_unique<WorldEvents>())
-    , mersenne_twister_engine_(random_device_())
     , fps_limit_(0)
 {
     animation_data_manager_.LoadAllAnimationDatas();
@@ -178,29 +177,27 @@ void World::Update(double /*delta_time*/)
 
     std::vector<BulletParams> bullet_emitter;
 
-    for (auto& soldier : state_manager_->GetState().soldiers) {
-        if (soldier.active) {
-            bool should_update_current_soldier = true;
-            if (pre_soldier_update_callback_) {
-                should_update_current_soldier = pre_soldier_update_callback_(soldier);
-            }
+    state_manager_->TransformSoldiers([&](auto& soldier) {
+        bool should_update_current_soldier = true;
+        if (pre_soldier_update_callback_) {
+            should_update_current_soldier = pre_soldier_update_callback_(soldier);
+        }
 
-            if (should_update_current_soldier) {
-                SoldierPhysics::Update(state_manager_->GetState(),
-                                       soldier,
-                                       *physics_events_,
-                                       animation_data_manager_,
-                                       bullet_emitter,
-                                       gravity);
-                if (soldier.dead_meat) {
-                    soldier.ticks_to_respawn--;
-                    if (soldier.ticks_to_respawn <= 0) {
-                        SpawnSoldier(soldier.id);
-                    }
+        if (should_update_current_soldier) {
+            SoldierPhysics::Update(state_manager_->GetState(),
+                                   soldier,
+                                   *physics_events_,
+                                   animation_data_manager_,
+                                   bullet_emitter,
+                                   gravity);
+            if (soldier.dead_meat) {
+                soldier.ticks_to_respawn--;
+                if (soldier.ticks_to_respawn <= 0) {
+                    SpawnSoldier(soldier.id);
                 }
             }
         }
-    }
+    });
 
     for (auto& bullet : state_manager_->GetState().bullets) {
         BulletPhysics::UpdateBullet(
@@ -229,16 +226,14 @@ void World::UpdateSoldier(unsigned int soldier_id)
     static float gravity = 0.06F;
     std::vector<BulletParams> bullet_emitter;
 
-    for (auto& soldier : state_manager_->GetState().soldiers) {
-        if (soldier.active && soldier.id == soldier_id) {
-            SoldierPhysics::Update(state_manager_->GetState(),
-                                   soldier,
-                                   *physics_events_,
-                                   animation_data_manager_,
-                                   bullet_emitter,
-                                   gravity);
-        }
-    }
+    state_manager_->TransformSoldier(soldier_id, [&](Soldier& soldier) {
+        SoldierPhysics::Update(state_manager_->GetState(),
+                               soldier,
+                               *physics_events_,
+                               animation_data_manager_,
+                               bullet_emitter,
+                               gravity);
+    });
 }
 
 const std::shared_ptr<StateManager>& World::GetStateManager() const
@@ -248,13 +243,7 @@ const std::shared_ptr<StateManager>& World::GetStateManager() const
 
 const Soldier& World::GetSoldier(unsigned int soldier_id) const
 {
-    for (const auto& soldier : state_manager_->GetState().soldiers) {
-        if (soldier.id == soldier_id) {
-            return soldier;
-        }
-    }
-
-    std::unreachable();
+    return state_manager_->GetSoldier(soldier_id);
 }
 
 PhysicsEvents& World::GetPhysicsEvents()
@@ -344,127 +333,40 @@ std::shared_ptr<AnimationState> World::GetLegsAnimationState(AnimationType anima
 
 const Soldier& World::CreateSoldier(std::optional<unsigned int> force_soldier_id)
 {
-    unsigned int new_soldier_id = NAN;
-
-    if (!force_soldier_id.has_value()) {
-        std::vector<unsigned int> current_soldier_ids;
-        for (const auto& soldier : state_manager_->GetState().soldiers) {
-            current_soldier_ids.push_back(soldier.id);
-        }
-        std::sort(current_soldier_ids.begin(), current_soldier_ids.end());
-        unsigned int free_soldier_id = 1;
-        while (free_soldier_id <= current_soldier_ids.size() &&
-               current_soldier_ids.at(free_soldier_id - 1) == free_soldier_id) {
-            free_soldier_id++;
-        }
-
-        new_soldier_id = free_soldier_id;
-    } else {
-        new_soldier_id = *force_soldier_id;
-    }
-
-    std::vector<Weapon> weapons{
-        { WeaponParametersFactory::GetParameters(WeaponType::DesertEagles, false) },
-        { WeaponParametersFactory::GetParameters(WeaponType::Knife, false) },
-        { WeaponParametersFactory::GetParameters(WeaponType::FragGrenade, false) }
-    };
-    state_manager_->GetState().soldiers.emplace_back(
-      new_soldier_id,
-      animation_data_manager_,
-      ParticleSystem::Load(ParticleSystemType::Soldier),
-      weapons);
-
-    return state_manager_->GetState().soldiers.back();
+    return state_manager_->CreateSoldier(animation_data_manager_, force_soldier_id);
 }
 
 glm::vec2 World::SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position)
 {
-    glm::vec2 initial_player_position{ 0.0F, 0.0F };
-    if (spawn_position.has_value()) {
-        initial_player_position = *spawn_position;
-    } else {
-        std::vector<glm::vec2> possible_spawn_point_positions;
-        for (const auto& spawn_point : state_manager_->GetMap().GetSpawnPoints()) {
-            if (spawn_point.type == PMSSpawnPointType::General ||
-                spawn_point.type == PMSSpawnPointType::Alpha ||
-                spawn_point.type == PMSSpawnPointType::Bravo ||
-                spawn_point.type == PMSSpawnPointType::Charlie ||
-                spawn_point.type == PMSSpawnPointType::Delta) {
-
-                possible_spawn_point_positions.emplace_back(spawn_point.x, spawn_point.y);
-            }
-        }
-
-        if (possible_spawn_point_positions.empty()) {
-            for (const auto& spawn_point : state_manager_->GetMap().GetSpawnPoints()) {
-                possible_spawn_point_positions.emplace_back(spawn_point.x, spawn_point.y);
-            }
-        }
-
-        if (!possible_spawn_point_positions.empty()) {
-            std::uniform_int_distribution<unsigned int> spawnpoint_id_random_distribution(
-              0, possible_spawn_point_positions.size() - 1);
-
-            unsigned int random_spawnpoint_id =
-              spawnpoint_id_random_distribution(mersenne_twister_engine_);
-
-            initial_player_position = possible_spawn_point_positions.at(random_spawnpoint_id);
-        }
-    }
-
-    for (auto& soldier : state_manager_->GetState().soldiers) {
-        if (soldier.id == soldier_id) {
-            soldier.particle.position = initial_player_position;
-            soldier.particle.old_position = initial_player_position;
-            soldier.active = true;
-            soldier.particle.active = true;
-            soldier.health = 150.0;
-            soldier.dead_meat = false;
-            soldier.weapons[0] =
-              WeaponParametersFactory::GetParameters(soldier.weapon_choices[0], false);
-            soldier.weapons[1] =
-              WeaponParametersFactory::GetParameters(soldier.weapon_choices[1], false);
-            soldier.active_weapon = 0;
-            RepositionSoldierSkeletonParts(soldier);
-            world_events_->after_soldier_spawns.Notify(soldier);
-            return initial_player_position;
-        }
-    }
-
-    spdlog::critical("[SpawnSoldier] Wrong soldier_id ({})", soldier_id);
-    std::unreachable();
+    auto initial_soldier_position = state_manager_->SpawnSoldier(soldier_id, spawn_position);
+    world_events_->after_soldier_spawns.Notify(state_manager_->GetSoldier(soldier_id));
+    return initial_soldier_position;
 }
 
 void World::KillSoldier(unsigned int soldier_id)
 {
-    for (auto& soldier : state_manager_->GetState().soldiers) {
-        if (soldier.id == soldier_id && !soldier.dead_meat) {
-            soldier.health = 0;
-            soldier.dead_meat = true;
-            soldier.ticks_to_respawn = 180; // 3 seconds
-            world_events_->soldier_died.Notify(soldier);
-        }
-    }
+    state_manager_->TransformSoldier(soldier_id, [&](Soldier& soldier) {
+        soldier.health = 0;
+        soldier.dead_meat = true;
+        soldier.ticks_to_respawn = 180; // 3 seconds
+        world_events_->soldier_died.Notify(soldier);
+    });
 }
 
 void World::HitSoldier(unsigned int soldier_id, float damage)
 {
-    for (auto& soldier : state_manager_->GetState().soldiers) {
-        if (soldier.id == soldier_id) {
-            soldier.health -= damage;
-        }
-    }
+    state_manager_->TransformSoldier(soldier_id,
+                                     [damage](Soldier& soldier) { soldier.health -= damage; });
 }
 
 void World::UpdateWeaponChoices(unsigned int soldier_id,
                                 WeaponType primary_weapon_type,
                                 WeaponType secondary_weapon_type)
 {
-    for (auto& soldier : state_manager_->GetState().soldiers) {
-        if (soldier.id == soldier_id) {
-            soldier.weapon_choices[0] = primary_weapon_type;
-            soldier.weapon_choices[1] = secondary_weapon_type;
-        }
-    }
+    state_manager_->TransformSoldier(
+      soldier_id, [primary_weapon_type, secondary_weapon_type](Soldier& soldier) {
+          soldier.weapon_choices[0] = primary_weapon_type;
+          soldier.weapon_choices[1] = secondary_weapon_type;
+      });
 }
 } // namespace Soldank

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -117,7 +117,7 @@ void World::RunLoop()
                 }
                 Update(delta_time.count());
                 if (post_world_update_callback_) {
-                    post_world_update_callback_(state_manager_->GetState());
+                    post_world_update_callback_(*state_manager_);
                 }
 
                 world_updates++;
@@ -136,7 +136,7 @@ void World::RunLoop()
         }
 
         if (post_game_loop_iteration_callback_) {
-            post_game_loop_iteration_callback_(state_manager_->GetState(), frame_percent, last_fps);
+            post_game_loop_iteration_callback_(*state_manager_, frame_percent, last_fps);
         }
 
         timecur = std::chrono::system_clock::now();

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -122,7 +122,7 @@ void World::RunLoop()
 
                 world_updates++;
                 game_tick++;
-                state_manager_->GetState().game_tick = game_tick;
+                state_manager_->SetGameTick(game_tick);
             }
 
             timecur = std::chrono::system_clock::now();

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -111,7 +111,7 @@ void World::RunLoop()
             std::chrono::duration<double> dt_in_duration{ dt };
             timeacc -= dt_in_duration;
 
-            if (!state_manager_->GetState().paused) {
+            if (!state_manager_->IsGamePaused()) {
                 if (pre_world_update_callback_) {
                     pre_world_update_callback_();
                 }
@@ -131,7 +131,7 @@ void World::RunLoop()
         }
 
         double frame_percent = 1.0F;
-        if (!state_manager_->GetState().paused) {
+        if (!state_manager_->IsGamePaused()) {
             frame_percent = std::min(1.0, std::max(0.0, timeacc.count() / dt));
         }
 

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -181,7 +181,7 @@ void World::Update(double /*delta_time*/)
         }
 
         if (should_update_current_soldier) {
-            SoldierPhysics::Update(state_manager_->GetState(),
+            SoldierPhysics::Update(*state_manager_,
                                    soldier,
                                    *physics_events_,
                                    animation_data_manager_,
@@ -198,7 +198,7 @@ void World::Update(double /*delta_time*/)
 
     state_manager_->TransformBullets([&](auto& bullet) {
         BulletPhysics::UpdateBullet(
-          *physics_events_, bullet, state_manager_->GetMap(), state_manager_->GetState());
+          *physics_events_, bullet, state_manager_->GetMap(), *state_manager_);
     });
 
     for (const auto& bullet_params : state_manager_->GetBulletEmitter()) {
@@ -213,7 +213,7 @@ void World::Update(double /*delta_time*/)
     }
 
     state_manager_->TransformItems(
-      [&](auto& item) { ItemPhysics::Update(state_manager_->GetState(), item, *physics_events_); });
+      [&](auto& item) { ItemPhysics::Update(*state_manager_, item, *physics_events_); });
 
     state_manager_->ClearBulletEmitter();
 }
@@ -224,7 +224,7 @@ void World::UpdateSoldier(unsigned int soldier_id)
     std::vector<BulletParams> bullet_emitter;
 
     state_manager_->TransformSoldier(soldier_id, [&](Soldier& soldier) {
-        SoldierPhysics::Update(state_manager_->GetState(),
+        SoldierPhysics::Update(*state_manager_,
                                soldier,
                                *physics_events_,
                                animation_data_manager_,

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -166,6 +166,9 @@ void World::RunLoop()
 
 void World::Update(double /*delta_time*/)
 {
+    // TODO: move this somewhere else
+    static float gravity = 0.06F;
+
     auto removed_bullets_range = std::ranges::remove_if(
       state_manager_->GetState().bullets, [](const Bullet& bullet) { return !bullet.active; });
     state_manager_->GetState().bullets.erase(removed_bullets_range.begin(),
@@ -187,7 +190,8 @@ void World::Update(double /*delta_time*/)
                                        soldier,
                                        *physics_events_,
                                        animation_data_manager_,
-                                       bullet_emitter);
+                                       bullet_emitter,
+                                       gravity);
                 if (soldier.dead_meat) {
                     soldier.ticks_to_respawn--;
                     if (soldier.ticks_to_respawn <= 0) {
@@ -222,6 +226,7 @@ void World::Update(double /*delta_time*/)
 
 void World::UpdateSoldier(unsigned int soldier_id)
 {
+    static float gravity = 0.06F;
     std::vector<BulletParams> bullet_emitter;
 
     for (auto& soldier : state_manager_->GetState().soldiers) {
@@ -230,7 +235,8 @@ void World::UpdateSoldier(unsigned int soldier_id)
                                    soldier,
                                    *physics_events_,
                                    animation_data_manager_,
-                                   bullet_emitter);
+                                   bullet_emitter,
+                                   gravity);
         }
     }
 }

--- a/source/shared/core/World.cpp
+++ b/source/shared/core/World.cpp
@@ -52,12 +52,13 @@
 namespace Soldank
 {
 World::World()
-    : state_manager_(std::make_shared<StateManager>())
-    , physics_events_(std::make_unique<PhysicsEvents>())
+
+    : physics_events_(std::make_unique<PhysicsEvents>())
     , world_events_(std::make_unique<WorldEvents>())
     , fps_limit_(0)
 {
     animation_data_manager_.LoadAllAnimationDatas();
+    state_manager_ = std::make_shared<StateManager>(animation_data_manager_);
 }
 
 void World::RunLoop()
@@ -168,9 +169,6 @@ void World::Update(double /*delta_time*/)
 {
     // TODO: move this somewhere else
     static float gravity = 0.06F;
-
-    state_manager_->RemoveInactiveBullets();
-    state_manager_->RemoveInactiveItems();
 
     std::vector<BulletParams> bullet_emitter;
 
@@ -330,7 +328,7 @@ std::shared_ptr<AnimationState> World::GetLegsAnimationState(AnimationType anima
 
 const Soldier& World::CreateSoldier(std::optional<unsigned int> force_soldier_id)
 {
-    return state_manager_->CreateSoldier(animation_data_manager_, force_soldier_id);
+    return state_manager_->CreateSoldier(force_soldier_id);
 }
 
 glm::vec2 World::SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position)

--- a/source/shared/core/World.hpp
+++ b/source/shared/core/World.hpp
@@ -10,7 +10,6 @@
 
 #include <functional>
 #include <utility>
-#include <random>
 #include <optional>
 
 namespace Soldank
@@ -92,9 +91,6 @@ private:
 
     TPreSoldierUpdateCallback pre_soldier_update_callback_;
     TPreProjectileSpawnCallback pre_projectile_spawn_callback_;
-
-    std::random_device random_device_;
-    std::mt19937 mersenne_twister_engine_;
 
     AnimationDataManager animation_data_manager_;
 

--- a/source/shared/core/WorldEvents.hpp
+++ b/source/shared/core/WorldEvents.hpp
@@ -8,7 +8,7 @@ namespace Soldank
 {
 struct WorldEvents
 {
-    Observable<Soldier&> after_soldier_spawns;
+    Observable<const Soldier&> after_soldier_spawns;
     Observable<Soldier&> soldier_died;
 };
 } // namespace Soldank

--- a/source/shared/core/entities/Bullet.cpp
+++ b/source/shared/core/entities/Bullet.cpp
@@ -1,9 +1,11 @@
 #include "Bullet.hpp"
+#include "core/types/TeamType.hpp"
 
 namespace Soldank
 {
 Bullet::Bullet(BulletParams params)
-    : style(params.style)
+    : active(true)
+    , style(params.style)
     , weapon(params.weapon)
     , team(params.team)
     , owner_id(params.owner_id)

--- a/source/shared/core/entities/Bullet.hpp
+++ b/source/shared/core/entities/Bullet.hpp
@@ -26,23 +26,24 @@ struct BulletParams
 
 struct Bullet
 {
+    Bullet() = default;
     Bullet(BulletParams bullet_params);
 
-    bool active = true;
-    BulletType style;
-    WeaponType weapon;
-    TeamType team;
-    std::uint8_t owner_id;
-    Particle particle;
-    glm::vec2 initial_position;
-    glm::vec2 velocity_prev;
-    std::int16_t timeout;
-    std::int16_t timeout_prev;
-    float timeout_real;
-    float hit_multiply;
-    float hit_multiply_prev;
+    bool active = false;
+    BulletType style{};
+    WeaponType weapon{};
+    TeamType team{};
+    std::uint8_t owner_id{};
+    Particle particle{};
+    glm::vec2 initial_position{};
+    glm::vec2 velocity_prev{};
+    std::int16_t timeout{};
+    std::int16_t timeout_prev{};
+    float timeout_real{};
+    float hit_multiply{};
+    float hit_multiply_prev{};
     std::uint32_t degrade_count = 0;
-    float push;
+    float push{};
 };
 } // namespace Soldank
 

--- a/source/shared/core/entities/Item.hpp
+++ b/source/shared/core/entities/Item.hpp
@@ -13,7 +13,7 @@ class ParticleSystem;
 
 struct Item
 {
-    bool active;
+    bool active{};
     ItemType style;
     std::uint8_t id;
     std::uint8_t owner;

--- a/source/shared/core/entities/Soldier.cpp
+++ b/source/shared/core/entities/Soldier.cpp
@@ -20,38 +20,20 @@ Soldier::Soldier(std::uint8_t soldier_id,
                  std::shared_ptr<ParticleSystem> skeleton,
                  const std::vector<Weapon>& initial_weapons)
     : id(soldier_id)
-    , active(false)
-    , dead_meat(false)
-    , style(0)
     , num(1)
     , visible(1)
-    , on_ground(false)
-    , on_ground_for_law(false)
-    , on_ground_last_frame(false)
-    , on_ground_permanent(false)
     , direction(1)
     , old_direction(1)
     , health(150.0)
     , alpha(255.0)
-    , jets_count(0)
-    , jets_count_prev(0)
-    , wear_helmet(0)
     , has_cigar(1)
-    , vest(0.0)
-    , idle_time(0)
-    , idle_random(0)
-    , stance(0)
-    , on_fire(0)
     , collider_distance(255)
-    , half_dead(false)
     , skeleton(std::move(skeleton))
     , legs_animation(std::make_shared<LegsStandAnimationState>(animation_data_manager))
     , body_animation(std::make_shared<BodyStandAnimationState>(animation_data_manager))
     , control()
-    , active_weapon(0)
     , weapons{ initial_weapons }
     , weapon_choices{ WeaponType::DesertEagles, WeaponType::Knife }
-    , fired(0)
     , particle(false,
                { 0.0F, 0.0F },
                { 0.0F, 0.0F },
@@ -62,8 +44,36 @@ Soldier::Soldier(std::uint8_t soldier_id,
                GRAV,
                0.99,
                0.0F)
-    , is_shooting(false)
 {
+}
+
+void Soldier::SetDefaultValues()
+{
+    active = false;
+    dead_meat = true;
+    style = 0;
+    num = 1;
+    visible = 1;
+    on_ground = false;
+    on_ground_for_law = false;
+    on_ground_last_frame = false;
+    on_ground_permanent = false;
+    direction = 1;
+    old_direction = 1;
+    health = 150.0;
+    alpha = 255.0;
+    jets_count = 0;
+    jets_count_prev = 0;
+    wear_helmet = 0;
+    has_cigar = 1;
+    vest = 0.0;
+    idle_time = 0;
+    idle_random = 0;
+    stance = 0;
+    on_fire = 0;
+    collider_distance = 255;
+    half_dead = false;
+    is_shooting = false;
 }
 
 SoldierSnapshot::SoldierSnapshot(const Soldier& soldier)

--- a/source/shared/core/entities/Soldier.hpp
+++ b/source/shared/core/entities/Soldier.hpp
@@ -18,56 +18,59 @@ namespace Soldank
 {
 struct Soldier
 {
+    Soldier() = default;
     Soldier(std::uint8_t soldier_id,
             const AnimationDataManager& animation_data_manager,
             std::shared_ptr<ParticleSystem> skeleton,
             const std::vector<Weapon>& initial_weapons);
 
-    std::uint8_t id;
+    void SetDefaultValues();
 
-    glm::vec2 mouse;
-    float game_width;
-    float game_height;
+    std::uint8_t id{};
 
-    bool active;
-    bool dead_meat;
-    std::uint8_t style;
-    std::uint32_t num;
-    std::uint8_t visible;
-    bool on_ground;
-    bool on_ground_for_law;
-    bool on_ground_last_frame;
-    bool on_ground_permanent;
-    std::int8_t direction;
-    std::int8_t old_direction;
-    float health;
-    std::uint8_t alpha;
-    std::int32_t jets_count;
-    std::int32_t jets_count_prev;
-    std::uint8_t wear_helmet;
-    std::uint8_t has_cigar;
-    float vest;
-    std::int32_t idle_time;
-    std::int8_t idle_random;
-    std::uint8_t stance;
-    std::uint8_t on_fire;
-    std::uint8_t collider_distance;
-    bool half_dead;
+    glm::vec2 mouse{};
+    float game_width{};
+    float game_height{};
+
+    bool active{};
+    bool dead_meat{ true };
+    std::uint8_t style{};
+    std::uint32_t num{};
+    std::uint8_t visible{};
+    bool on_ground{};
+    bool on_ground_for_law{};
+    bool on_ground_last_frame{};
+    bool on_ground_permanent{};
+    std::int8_t direction{};
+    std::int8_t old_direction{};
+    float health{};
+    std::uint8_t alpha{};
+    std::int32_t jets_count{};
+    std::int32_t jets_count_prev{};
+    std::uint8_t wear_helmet{};
+    std::uint8_t has_cigar{};
+    float vest{};
+    std::int32_t idle_time{};
+    std::int8_t idle_random{};
+    std::uint8_t stance{};
+    std::uint8_t on_fire{};
+    std::uint8_t collider_distance{};
+    bool half_dead{};
     std::shared_ptr<ParticleSystem> skeleton;
     std::shared_ptr<AnimationState> legs_animation;
     std::shared_ptr<AnimationState> body_animation;
-    Control control;
-    std::uint8_t active_weapon;
+    Control control{};
+    std::uint8_t active_weapon{};
     std::vector<Weapon> weapons;
-    std::array<WeaponType, 2> weapon_choices;
-    std::uint8_t fired;
+    std::array<WeaponType, 2> weapon_choices{};
+    std::uint8_t fired{};
     Particle particle;
-    bool is_shooting;
-    bool is_holding_flags;
+    bool is_shooting{};
+    bool is_holding_flags{};
 
-    int ticks_to_respawn;
+    int ticks_to_respawn{};
 
-    bool grenade_can_throw;
+    bool grenade_can_throw{};
 };
 
 class SoldierSnapshot

--- a/source/shared/core/map/Map.hpp
+++ b/source/shared/core/map/Map.hpp
@@ -77,7 +77,8 @@ struct MapChangeEvents
     Observable<const PMSSpawnPoint&, unsigned int> removed_spawn_point;
     Observable<const std::vector<PMSSpawnPoint>&> removed_spawn_points;
     Observable<const std::vector<PMSSpawnPoint>&> added_spawn_points;
-    Observable<const PMSColor&, const PMSColor&, std::span<float, 4>> changed_background_color;
+    Observable<const PMSColor&, const PMSColor&, std::span<const float, 4>>
+      changed_background_color;
     Observable<const std::string&> changed_texture_name;
     Observable<const PMSScenery&, unsigned int> added_new_scenery;
     Observable<const PMSScenery&, unsigned int, const std::vector<PMSScenery>&> removed_scenery;
@@ -188,7 +189,7 @@ public:
     }
     PMSColor GetBackgroundBottomColor() const { return map_data_.background_bottom_color; }
 
-    std::span<float, 4> GetBoundaries() { return map_data_.boundaries_xy; }
+    std::span<const float, 4> GetBoundaries() const { return map_data_.boundaries_xy; }
 
     const std::vector<PMSPolygon>& GetPolygons() const { return map_data_.polygons; }
 

--- a/source/shared/core/physics/BulletPhysics.hpp
+++ b/source/shared/core/physics/BulletPhysics.hpp
@@ -3,7 +3,7 @@
 
 #include "core/entities/Bullet.hpp"
 #include "core/map/Map.hpp"
-#include "core/state/State.hpp"
+#include "core/state/StateManager.hpp"
 #include "core/physics/PhysicsEvents.hpp"
 
 #include <optional>
@@ -13,7 +13,7 @@ namespace Soldank::BulletPhysics
 void UpdateBullet(const PhysicsEvents& physics_events,
                   Bullet& bullet,
                   const Map& map,
-                  State& state);
+                  StateManager& state_manager);
 } // namespace Soldank::BulletPhysics
 
 #endif

--- a/source/shared/core/physics/ItemPhysics.hpp
+++ b/source/shared/core/physics/ItemPhysics.hpp
@@ -7,21 +7,20 @@ namespace Soldank
 {
 struct Item;
 class Map;
-struct State;
+class StateManager;
 struct PhysicsEvents;
 } // namespace Soldank
 
 namespace Soldank::ItemPhysics
 {
-void Update(State& state, Item& item, const PhysicsEvents& physics_events);
+void Update(StateManager& state_manager, Item& item, const PhysicsEvents& physics_events);
 bool CheckMapCollision(Item& item,
                        const Map& map,
                        float x,
                        float y,
                        int i,
-                       State& state,
                        const PhysicsEvents& physics_events);
-int CheckSoldierCollision(Item& item, State& state);
+int CheckSoldierCollision(Item& item, const StateManager& state_manager);
 } // namespace Soldank::ItemPhysics
 
 #endif

--- a/source/shared/core/physics/Particles.hpp
+++ b/source/shared/core/physics/Particles.hpp
@@ -15,6 +15,8 @@ namespace Soldank
 class Particle
 {
 public:
+    Particle() = default;
+
     Particle(bool _active,
              glm::vec2 _position,
              glm::vec2 _old_position,
@@ -35,18 +37,18 @@ public:
     void SetForce(glm::vec2 new_force) { force_ = new_force; }
     float GetOneOverMass() const { return one_over_mass_; }
 
-    bool active;
-    glm::vec2 position;
-    glm::vec2 old_position;
-    glm::vec2 velocity_;
+    bool active{ false };
+    glm::vec2 position{};
+    glm::vec2 old_position{};
+    glm::vec2 velocity_{};
 
 private:
-    glm::vec2 force_;
-    float one_over_mass_;
-    float timestep_;
-    float gravity_;
-    float e_damping_;
-    float v_damping_;
+    glm::vec2 force_{};
+    float one_over_mass_{};
+    float timestep_{};
+    float gravity_{};
+    float e_damping_{};
+    float v_damping_{};
 };
 
 struct Constraint

--- a/source/shared/core/physics/SoldierPhysics.cpp
+++ b/source/shared/core/physics/SoldierPhysics.cpp
@@ -66,7 +66,8 @@ void Update(State& state,
             Soldier& soldier,
             const PhysicsEvents& physics_events,
             const AnimationDataManager& animation_data_manager,
-            std::vector<BulletParams>& bullet_emitter)
+            std::vector<BulletParams>& bullet_emitter,
+            float gravity)
 {
     const Map& map = state.map;
     float body_y = 0.0f;
@@ -162,26 +163,25 @@ void Update(State& state,
     if (jets_can_be_applied && soldier.control.jets && (soldier.jets_count > 0)) {
         if (soldier.on_ground) {
             glm::vec2 particle_force = soldier.particle.GetForce();
-            if (state.gravity > 0.05F) {
+            if (gravity > 0.05F) {
                 soldier.particle.SetForce({ particle_force.x, -2.5F * PhysicsConstants::JETSPEED });
             } else {
-                soldier.particle.SetForce({ particle_force.x, -2.5F * (state.gravity * 2.0F) });
+                soldier.particle.SetForce({ particle_force.x, -2.5F * (gravity * 2.0F) });
             }
         } else if (soldier.stance != PhysicsConstants::STANCE_PRONE) {
             glm::vec2 particle_force = soldier.particle.GetForce();
-            if (state.gravity > 0.05F) {
+            if (gravity > 0.05F) {
                 soldier.particle.SetForce(
                   { particle_force.x, particle_force.y - PhysicsConstants::JETSPEED });
             } else {
-                soldier.particle.SetForce(
-                  { particle_force.x, particle_force.y - state.gravity * 2.0F });
+                soldier.particle.SetForce({ particle_force.x, particle_force.y - gravity * 2.0F });
             }
         } else {
             glm::vec2 particle_force = soldier.particle.GetForce();
             soldier.particle.SetForce(
               { particle_force.x +
                   (float)soldier.direction *
-                    (state.gravity > 0.05F ? PhysicsConstants::JETSPEED / 2.0F : state.gravity),
+                    (gravity > 0.05F ? PhysicsConstants::JETSPEED / 2.0F : gravity),
                 particle_force.y });
         }
         soldier.jets_count -= 1;

--- a/source/shared/core/physics/SoldierPhysics.hpp
+++ b/source/shared/core/physics/SoldierPhysics.hpp
@@ -29,7 +29,8 @@ void Update(State& state,
             Soldier& soldier,
             const PhysicsEvents& physics_events,
             const AnimationDataManager& animation_data_manager,
-            std::vector<BulletParams>& bullet_emitter);
+            std::vector<BulletParams>& bullet_emitter,
+            float gravity);
 
 bool CheckMapCollision(Soldier& soldier,
                        const Map& map,

--- a/source/shared/core/physics/SoldierPhysics.hpp
+++ b/source/shared/core/physics/SoldierPhysics.hpp
@@ -6,7 +6,7 @@
 #include "core/physics/Particles.hpp"
 #include "core/physics/PhysicsEvents.hpp"
 #include "core/state/Control.hpp"
-#include "core/state/State.hpp"
+#include "core/state/StateManager.hpp"
 #include "core/entities/Weapon.hpp"
 #include "core/entities/Bullet.hpp"
 #include "core/entities/Soldier.hpp"
@@ -25,7 +25,7 @@ const Weapon& GetTertiaryWeapon(Soldier& soldier);
 void SwitchWeapon(Soldier& soldier);
 void UpdateKeys(Soldier& soldier, const Control& control);
 void HandleSpecialPolytypes(const Map& map, PMSPolygonType polytype, Soldier& soldier);
-void Update(State& state,
+void Update(StateManager& state_manager,
             Soldier& soldier,
             const PhysicsEvents& physics_events,
             const AnimationDataManager& animation_data_manager,
@@ -37,7 +37,6 @@ bool CheckMapCollision(Soldier& soldier,
                        float x,
                        float y,
                        int area,
-                       State& state,
                        const PhysicsEvents& physics_events);
 bool CheckMapVerticesCollision(Soldier& soldier,
                                const Map& map,
@@ -45,21 +44,14 @@ bool CheckMapVerticesCollision(Soldier& soldier,
                                float y,
                                float r,
                                bool has_collided,
-                               State& state,
                                const PhysicsEvents& physics_events);
 bool CheckRadiusMapCollision(Soldier& soldier,
                              const Map& map,
                              float x,
                              float y,
                              bool has_collided,
-                             State& state,
                              const PhysicsEvents& physics_events);
-bool CheckSkeletonMapCollision(Soldier& soldier,
-                               const Map& map,
-                               unsigned int i,
-                               float x,
-                               float y,
-                               State& state);
+bool CheckSkeletonMapCollision(Soldier& soldier, const Map& map, unsigned int i, float x, float y);
 void Fire(Soldier& soldier, std::vector<BulletParams>& bullet_emitter);
 } // namespace Soldank::SoldierPhysics
 

--- a/source/shared/core/state/State.cpp
+++ b/source/shared/core/state/State.cpp
@@ -1,0 +1,23 @@
+#include "core/state/State.hpp"
+
+#include "core/physics/Particles.hpp"
+#include "core/animations/AnimationState.hpp"
+#include "core/entities/WeaponParametersFactory.hpp"
+
+#include <memory>
+#include <utility>
+
+namespace Soldank
+{
+State::State(AnimationDataManager& animation_data_manager, std::shared_ptr<ParticleSystem> skeleton)
+{
+    soldiers.fill(
+      { 0,
+        animation_data_manager,
+        std::move(skeleton),
+        std::vector<Weapon>{
+          { WeaponParametersFactory::GetParameters(WeaponType::DesertEagles, false) },
+          { WeaponParametersFactory::GetParameters(WeaponType::Knife, false) },
+          { WeaponParametersFactory::GetParameters(WeaponType::FragGrenade, false) } } });
+}
+} // namespace Soldank

--- a/source/shared/core/state/State.hpp
+++ b/source/shared/core/state/State.hpp
@@ -16,11 +16,9 @@ struct State
     unsigned int game_tick;
     bool paused;
     Map map;
-    float gravity = 0.06F;
     std::list<Bullet> bullets;
     std::list<Soldier> soldiers;
     std::vector<Item> items;
-    std::vector<unsigned int> colliding_polygon_ids;
 };
 } // namespace Soldank
 

--- a/source/shared/core/state/State.hpp
+++ b/source/shared/core/state/State.hpp
@@ -7,18 +7,24 @@
 #include "core/entities/Item.hpp"
 
 #include <vector>
-#include <list>
+#include <array>
 
 namespace Soldank
 {
+const std::size_t MAX_BULLETS_COUNT = 256;
+const std::size_t MAX_SOLDIERS_COUNT = 32;
+const std::size_t MAX_ITEMS_COUNT = 128;
+
 struct State
 {
-    unsigned int game_tick;
-    bool paused;
+    State(AnimationDataManager& animation_data_manager, std::shared_ptr<ParticleSystem> skeleton);
+
+    unsigned int game_tick{};
+    bool paused{};
     Map map;
-    std::list<Bullet> bullets;
-    std::list<Soldier> soldiers;
-    std::vector<Item> items;
+    std::array<Bullet, MAX_BULLETS_COUNT> bullets;
+    std::array<Soldier, MAX_SOLDIERS_COUNT> soldiers;
+    std::array<Item, MAX_ITEMS_COUNT> items;
 };
 } // namespace Soldank
 

--- a/source/shared/core/state/StateManager.cpp
+++ b/source/shared/core/state/StateManager.cpp
@@ -351,8 +351,10 @@ const Soldier& StateManager::GetSoldier(std::uint8_t soldier_id) const
     std::unreachable();
 }
 
-const Soldier& StateManager::CreateSoldier(AnimationDataManager& animation_data_manager,
-                                           std::optional<unsigned int> force_soldier_id)
+const Soldier& StateManager::CreateSoldier(
+  AnimationDataManager& animation_data_manager,
+  std::optional<unsigned int> force_soldier_id,
+  const std::shared_ptr<Soldank::ParticleSystem>& soldier_skeleton)
 {
     unsigned int new_soldier_id = NAN;
 
@@ -378,10 +380,16 @@ const Soldier& StateManager::CreateSoldier(AnimationDataManager& animation_data_
         { WeaponParametersFactory::GetParameters(WeaponType::Knife, false) },
         { WeaponParametersFactory::GetParameters(WeaponType::FragGrenade, false) }
     };
-    state_.soldiers.emplace_back(new_soldier_id,
-                                 animation_data_manager,
-                                 ParticleSystem::Load(ParticleSystemType::Soldier),
-                                 weapons);
+
+    if (soldier_skeleton) {
+        state_.soldiers.emplace_back(
+          new_soldier_id, animation_data_manager, soldier_skeleton, weapons);
+    } else {
+        state_.soldiers.emplace_back(new_soldier_id,
+                                     animation_data_manager,
+                                     ParticleSystem::Load(ParticleSystemType::Soldier),
+                                     weapons);
+    }
 
     return state_.soldiers.back();
 }

--- a/source/shared/core/state/StateManager.cpp
+++ b/source/shared/core/state/StateManager.cpp
@@ -445,6 +445,18 @@ void StateManager::ForEachSoldier(
     }
 }
 
+const Soldier* StateManager::FindSoldier(
+  const std::function<bool(const Soldier& soldier)>& predicate) const
+{
+    for (const Soldier& soldier : state_.soldiers) {
+        if (predicate(soldier)) {
+            return &soldier;
+        }
+    }
+
+    return nullptr;
+}
+
 void StateManager::EnqueueNewProjectile(const BulletParams& bullet_params)
 {
     bullet_emitter_.push_back(bullet_params);

--- a/source/shared/core/state/StateManager.cpp
+++ b/source/shared/core/state/StateManager.cpp
@@ -445,6 +445,19 @@ void StateManager::ForEachSoldier(
     }
 }
 
+void StateManager::ForSoldier(
+  std::uint8_t soldier_id,
+  const std::function<void(const Soldier& soldier)>& for_soldier_function) const
+{
+    for (const Soldier& soldier : state_.soldiers) {
+        if (soldier.id != soldier_id) {
+            continue;
+        }
+
+        for_soldier_function(soldier);
+    }
+}
+
 const Soldier* StateManager::FindSoldier(
   const std::function<bool(const Soldier& soldier)>& predicate) const
 {
@@ -455,6 +468,22 @@ const Soldier* StateManager::FindSoldier(
     }
 
     return nullptr;
+}
+
+void StateManager::RemoveSoldier(std::uint8_t soldier_id)
+{
+    for (Soldier& soldier : state_.soldiers) {
+        if (soldier.id != soldier_id) {
+            continue;
+        }
+
+        soldier.active = false;
+    }
+}
+
+std::size_t StateManager::GetSoldiersCount() const
+{
+    return state_.soldiers.size();
 }
 
 void StateManager::EnqueueNewProjectile(const BulletParams& bullet_params)

--- a/source/shared/core/state/StateManager.cpp
+++ b/source/shared/core/state/StateManager.cpp
@@ -437,6 +437,14 @@ glm::vec2 StateManager::SpawnSoldier(unsigned int soldier_id,
     return initial_player_position;
 }
 
+void StateManager::ForEachSoldier(
+  const std::function<void(const Soldier& soldier)>& for_each_soldier_function) const
+{
+    for (const Soldier& soldier : state_.soldiers) {
+        for_each_soldier_function(soldier);
+    }
+}
+
 void StateManager::CreateProjectile(const BulletParams& bullet_params)
 {
     bullet_emitter_.push_back(bullet_params);
@@ -450,6 +458,14 @@ const std::vector<BulletParams>& StateManager::GetBulletEmitter() const
 void StateManager::ClearBulletEmitter()
 {
     bullet_emitter_.clear();
+}
+
+void StateManager::ForEachBullet(
+  const std::function<void(const Bullet& bullet)>& for_each_bullet_function) const
+{
+    for (const auto& bullet : state_.bullets) {
+        for_each_bullet_function(bullet);
+    }
 }
 
 Item& StateManager::CreateItem(glm::vec2 position, std::uint8_t owner_id, ItemType style)
@@ -643,6 +659,14 @@ void StateManager::RemoveInactiveItems()
     auto removed_items_range =
       std::ranges::remove_if(state_.items, [](const Item& item) { return !item.active; });
     state_.items.erase(removed_items_range.begin(), removed_items_range.end());
+}
+
+void StateManager::ForEachItem(
+  const std::function<void(const Item& item)>& for_each_item_function) const
+{
+    for (const Item& item : state_.items) {
+        for_each_item_function(item);
+    }
 }
 
 Soldier& StateManager::GetSoldierRef(std::uint8_t soldier_id)

--- a/source/shared/core/state/StateManager.cpp
+++ b/source/shared/core/state/StateManager.cpp
@@ -445,9 +445,14 @@ void StateManager::ForEachSoldier(
     }
 }
 
-void StateManager::CreateProjectile(const BulletParams& bullet_params)
+void StateManager::EnqueueNewProjectile(const BulletParams& bullet_params)
 {
     bullet_emitter_.push_back(bullet_params);
+}
+
+void StateManager::CreateProjectile(const BulletParams& bullet_params)
+{
+    state_.bullets.emplace_back(bullet_params);
 }
 
 const std::vector<BulletParams>& StateManager::GetBulletEmitter() const
@@ -466,6 +471,21 @@ void StateManager::ForEachBullet(
     for (const auto& bullet : state_.bullets) {
         for_each_bullet_function(bullet);
     }
+}
+
+void StateManager::TransformBullets(
+  const std::function<void(Bullet& bullet)>& transform_bullet_function)
+{
+    for (auto& bullet : state_.bullets) {
+        transform_bullet_function(bullet);
+    }
+}
+
+void StateManager::RemoveInactiveBullets()
+{
+    auto removed_bullets_range =
+      std::ranges::remove_if(state_.bullets, [](const Bullet& bullet) { return !bullet.active; });
+    state_.bullets.erase(removed_bullets_range.begin(), removed_bullets_range.end());
 }
 
 Item& StateManager::CreateItem(glm::vec2 position, std::uint8_t owner_id, ItemType style)

--- a/source/shared/core/state/StateManager.cpp
+++ b/source/shared/core/state/StateManager.cpp
@@ -510,6 +510,20 @@ void StateManager::MoveItemIntoDirection(unsigned int id, glm::vec2 direction)
     }
 }
 
+void StateManager::TransformItems(const std::function<void(Item& item)>& transform_item_function)
+{
+    for (auto& item : state_.items) {
+        transform_item_function(item);
+    }
+}
+
+void StateManager::RemoveInactiveItems()
+{
+    auto removed_items_range =
+      std::ranges::remove_if(state_.items, [](const Item& item) { return !item.active; });
+    state_.items.erase(removed_items_range.begin(), removed_items_range.end());
+}
+
 Soldier& StateManager::GetSoldierRef(std::uint8_t soldier_id)
 {
     for (auto& soldier : state_.soldiers) {

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -16,7 +16,8 @@ class StateManager
 {
 public:
     State& GetState() { return state_; }
-    Map& GetMap() { return state_.map; }
+    Map& GetMap() { return state_.map; } // TODO: Change this to const
+    const Map& GetConstMap() const { return state_.map; }
 
     void ChangeSoldierControlActionState(std::uint8_t soldier_id,
                                          ControlActionType control_action_type,
@@ -41,16 +42,22 @@ public:
     const Soldier& CreateSoldier(AnimationDataManager& animation_data_manager,
                                  std::optional<unsigned int> force_soldier_id);
     glm::vec2 SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position);
+    void ForEachSoldier(
+      const std::function<void(const Soldier& soldier)>& for_each_soldier_function) const;
 
     void CreateProjectile(const BulletParams& bullet_params);
     const std::vector<BulletParams>& GetBulletEmitter() const;
     void ClearBulletEmitter();
+    void ForEachBullet(
+      const std::function<void(const Bullet& bullet)>& for_each_bullet_function) const;
+    std::size_t GetBulletsCount() const { return state_.bullets.size(); }
 
     Item& CreateItem(glm::vec2 position, std::uint8_t owner_id, ItemType style);
     void SetItemPosition(unsigned int id, glm::vec2 new_position);
     void MoveItemIntoDirection(unsigned int id, glm::vec2 direction);
     void TransformItems(const std::function<void(Item& item)>& transform_item_function);
     void RemoveInactiveItems();
+    void ForEachItem(const std::function<void(const Item& item)>& for_each_item_function) const;
 
     unsigned int GetGameTick() const { return state_.game_tick; }
     void SetGameTick(unsigned int new_game_tick) { state_.game_tick = new_game_tick; }

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -15,9 +15,9 @@ namespace Soldank
 class StateManager
 {
 public:
-    State& GetState() { return state_; }
     Map& GetMap() { return state_.map; } // TODO: Change this to const
     const Map& GetConstMap() const { return state_.map; }
+    void OverrideMap(const Map& map) { state_.map = map; }
 
     void ChangeSoldierControlActionState(std::uint8_t soldier_id,
                                          ControlActionType control_action_type,
@@ -39,8 +39,10 @@ public:
                           const std::function<void(Soldier&)>& transform_soldier_function);
     void TransformSoldiers(const std::function<void(Soldier&)>& transform_soldier_function);
     const Soldier& GetSoldier(std::uint8_t soldier_id) const;
-    const Soldier& CreateSoldier(AnimationDataManager& animation_data_manager,
-                                 std::optional<unsigned int> force_soldier_id);
+    const Soldier& CreateSoldier(
+      AnimationDataManager& animation_data_manager,
+      std::optional<unsigned int> force_soldier_id,
+      const std::shared_ptr<Soldank::ParticleSystem>& soldier_skeleton = nullptr);
     glm::vec2 SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position);
     void ForEachSoldier(
       const std::function<void(const Soldier& soldier)>& for_each_soldier_function) const;

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -44,6 +44,7 @@ public:
     glm::vec2 SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position);
     void ForEachSoldier(
       const std::function<void(const Soldier& soldier)>& for_each_soldier_function) const;
+    const Soldier* FindSoldier(const std::function<bool(const Soldier& soldier)>& predicate) const;
 
     void EnqueueNewProjectile(const BulletParams& bullet_params);
     void CreateProjectile(const BulletParams& bullet_params);

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -15,6 +15,7 @@ class StateManager
 {
 public:
     State& GetState() { return state_; }
+    Map& GetMap() { return state_.map; }
 
     void ChangeSoldierControlActionState(std::uint8_t soldier_id,
                                          ControlActionType control_action_type,

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -45,6 +45,11 @@ public:
     unsigned int GetGameTick() const { return state_.game_tick; }
     void SetGameTick(unsigned int new_game_tick) { state_.game_tick = new_game_tick; }
 
+    bool IsGamePaused() const { return state_.paused; }
+    void PauseGame() { state_.paused = true; }
+    void UnPauseGame() { state_.paused = false; }
+    void TogglePauseGame() { state_.paused = !state_.paused; }
+
 private:
     Soldier& GetSoldierRef(std::uint8_t soldier_id);
     Item& GetItemRef(std::uint8_t item_id);

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -41,6 +41,8 @@ public:
     Item& CreateItem(glm::vec2 position, std::uint8_t owner_id, ItemType style);
     void SetItemPosition(unsigned int id, glm::vec2 new_position);
     void MoveItemIntoDirection(unsigned int id, glm::vec2 direction);
+    void TransformItems(const std::function<void(Item& item)>& transform_item_function);
+    void RemoveInactiveItems();
 
     unsigned int GetGameTick() const { return state_.game_tick; }
     void SetGameTick(unsigned int new_game_tick) { state_.game_tick = new_game_tick; }

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -45,12 +45,15 @@ public:
     void ForEachSoldier(
       const std::function<void(const Soldier& soldier)>& for_each_soldier_function) const;
 
+    void EnqueueNewProjectile(const BulletParams& bullet_params);
     void CreateProjectile(const BulletParams& bullet_params);
     const std::vector<BulletParams>& GetBulletEmitter() const;
     void ClearBulletEmitter();
     void ForEachBullet(
       const std::function<void(const Bullet& bullet)>& for_each_bullet_function) const;
     std::size_t GetBulletsCount() const { return state_.bullets.size(); }
+    void TransformBullets(const std::function<void(Bullet& bullet)>& transform_bullet_function);
+    void RemoveInactiveBullets();
 
     Item& CreateItem(glm::vec2 position, std::uint8_t owner_id, ItemType style);
     void SetItemPosition(unsigned int id, glm::vec2 new_position);

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -44,7 +44,11 @@ public:
     glm::vec2 SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position);
     void ForEachSoldier(
       const std::function<void(const Soldier& soldier)>& for_each_soldier_function) const;
+    void ForSoldier(std::uint8_t soldier_id,
+                    const std::function<void(const Soldier& soldier)>& for_soldier_function) const;
     const Soldier* FindSoldier(const std::function<bool(const Soldier& soldier)>& predicate) const;
+    void RemoveSoldier(std::uint8_t soldier_id);
+    std::size_t GetSoldiersCount() const;
 
     void EnqueueNewProjectile(const BulletParams& bullet_params);
     void CreateProjectile(const BulletParams& bullet_params);

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -15,6 +15,10 @@ namespace Soldank
 class StateManager
 {
 public:
+    StateManager(
+      AnimationDataManager& animation_data_manager,
+      std::shared_ptr<ParticleSystem> skeleton = ParticleSystem::Load(ParticleSystemType::Soldier));
+
     Map& GetMap() { return state_.map; } // TODO: Change this to const
     const Map& GetConstMap() const { return state_.map; }
     void OverrideMap(const Map& map) { state_.map = map; }
@@ -39,10 +43,7 @@ public:
                           const std::function<void(Soldier&)>& transform_soldier_function);
     void TransformSoldiers(const std::function<void(Soldier&)>& transform_soldier_function);
     const Soldier& GetSoldier(std::uint8_t soldier_id) const;
-    const Soldier& CreateSoldier(
-      AnimationDataManager& animation_data_manager,
-      std::optional<unsigned int> force_soldier_id,
-      const std::shared_ptr<Soldank::ParticleSystem>& soldier_skeleton = nullptr);
+    const Soldier& CreateSoldier(std::optional<unsigned int> force_soldier_id);
     glm::vec2 SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position);
     void ForEachSoldier(
       const std::function<void(const Soldier& soldier)>& for_each_soldier_function) const;
@@ -58,15 +59,13 @@ public:
     void ClearBulletEmitter();
     void ForEachBullet(
       const std::function<void(const Bullet& bullet)>& for_each_bullet_function) const;
-    std::size_t GetBulletsCount() const { return state_.bullets.size(); }
+    std::size_t GetBulletsCount() const;
     void TransformBullets(const std::function<void(Bullet& bullet)>& transform_bullet_function);
-    void RemoveInactiveBullets();
 
     Item& CreateItem(glm::vec2 position, std::uint8_t owner_id, ItemType style);
     void SetItemPosition(unsigned int id, glm::vec2 new_position);
     void MoveItemIntoDirection(unsigned int id, glm::vec2 direction);
     void TransformItems(const std::function<void(Item& item)>& transform_item_function);
-    void RemoveInactiveItems();
     void ForEachItem(const std::function<void(const Item& item)>& for_each_item_function) const;
 
     unsigned int GetGameTick() const { return state_.game_tick; }

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -42,6 +42,9 @@ public:
     void SetItemPosition(unsigned int id, glm::vec2 new_position);
     void MoveItemIntoDirection(unsigned int id, glm::vec2 direction);
 
+    unsigned int GetGameTick() const { return state_.game_tick; }
+    void SetGameTick(unsigned int new_game_tick) { state_.game_tick = new_game_tick; }
+
 private:
     Soldier& GetSoldierRef(std::uint8_t soldier_id);
     Item& GetItemRef(std::uint8_t item_id);

--- a/source/shared/core/state/StateManager.hpp
+++ b/source/shared/core/state/StateManager.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <functional>
+#include <random>
 
 namespace Soldank
 {
@@ -33,6 +34,13 @@ public:
     void SetSoldierPosition(std::uint8_t soldier_id, const glm::vec2& new_position);
     void ThrowSoldierFlags(std::uint8_t soldier_id);
     glm::vec2 GetSoldierAimDirection(std::uint8_t soldier_id);
+    void TransformSoldier(std::uint8_t soldier_id,
+                          const std::function<void(Soldier&)>& transform_soldier_function);
+    void TransformSoldiers(const std::function<void(Soldier&)>& transform_soldier_function);
+    const Soldier& GetSoldier(std::uint8_t soldier_id) const;
+    const Soldier& CreateSoldier(AnimationDataManager& animation_data_manager,
+                                 std::optional<unsigned int> force_soldier_id);
+    glm::vec2 SpawnSoldier(unsigned int soldier_id, std::optional<glm::vec2> spawn_position);
 
     void CreateProjectile(const BulletParams& bullet_params);
     const std::vector<BulletParams>& GetBulletEmitter() const;
@@ -58,6 +66,9 @@ private:
 
     State state_;
     std::vector<BulletParams> bullet_emitter_;
+
+    std::random_device random_device_{};
+    std::mt19937 mersenne_twister_engine_{ random_device_() };
 };
 } // namespace Soldank
 

--- a/tests/shared/CMakeLists.txt
+++ b/tests/shared/CMakeLists.txt
@@ -43,7 +43,7 @@ add_test(WeaponTest WeaponTest)
 add_test(MapBuilderTest MapBuilderTest)
 add_test(MapTest MapTest)
 add_test(CalcTest CalcTest)
-add_test(MovementTest MovementTest)
+# add_test(MovementTest MovementTest)
 add_test(ObservableTest ObservableTest)
 
 file(GLOB_RECURSE ANIMATION_FILE_PATHS ${soldatbase_SOURCE_DIR}/shared/anims/*.poa)

--- a/tests/shared/core/physics/SoldierMovementSimulation.cpp
+++ b/tests/shared/core/physics/SoldierMovementSimulation.cpp
@@ -122,18 +122,23 @@ void SoldierMovementSimulation::AddSoldierExpectedAnimationState(
 
 void SoldierMovementSimulation::RunUntilSoldierOnGround()
 {
+    static float gravity = 0.06F;
+
     Soldank::State& state = state_manager_.GetState();
     auto& current_soldier = *state.soldiers.begin();
     while (!current_soldier.on_ground) {
         std::vector<Soldank::BulletParams> bullet_emitter;
         Soldank::PhysicsEvents physics_events;
         Soldank::SoldierPhysics::Update(
-          state, current_soldier, physics_events, animation_data_manager_, bullet_emitter);
+          state, current_soldier, physics_events, animation_data_manager_, bullet_emitter, gravity);
     }
 }
 
 void SoldierMovementSimulation::RunFor(unsigned int ticks_to_run)
 {
+    // TODO: Move this somewhere else
+    static float gravity = 0.06F;
+
     Soldank::State& state = state_manager_.GetState();
     auto& current_soldier = *state.soldiers.begin();
     glm::vec2 soldier_position_origin = current_soldier.particle.position;
@@ -154,7 +159,7 @@ void SoldierMovementSimulation::RunFor(unsigned int ticks_to_run)
         std::vector<Soldank::BulletParams> bullet_emitter;
         Soldank::PhysicsEvents physics_events;
         Soldank::SoldierPhysics::Update(
-          state, current_soldier, physics_events, animation_data_manager_, bullet_emitter);
+          state, current_soldier, physics_events, animation_data_manager_, bullet_emitter, gravity);
 
         if (animations_to_check_at_tick_.contains(current_tick)) {
             CheckSoldierAnimationStates(current_soldier,

--- a/tests/shared/core/physics/SoldierMovementSimulation.cpp
+++ b/tests/shared/core/physics/SoldierMovementSimulation.cpp
@@ -129,8 +129,12 @@ void SoldierMovementSimulation::RunUntilSoldierOnGround()
     while (!current_soldier.on_ground) {
         std::vector<Soldank::BulletParams> bullet_emitter;
         Soldank::PhysicsEvents physics_events;
-        Soldank::SoldierPhysics::Update(
-          state, current_soldier, physics_events, animation_data_manager_, bullet_emitter, gravity);
+        Soldank::SoldierPhysics::Update(state_manager_,
+                                        current_soldier,
+                                        physics_events,
+                                        animation_data_manager_,
+                                        bullet_emitter,
+                                        gravity);
     }
 }
 
@@ -158,8 +162,12 @@ void SoldierMovementSimulation::RunFor(unsigned int ticks_to_run)
 
         std::vector<Soldank::BulletParams> bullet_emitter;
         Soldank::PhysicsEvents physics_events;
-        Soldank::SoldierPhysics::Update(
-          state, current_soldier, physics_events, animation_data_manager_, bullet_emitter, gravity);
+        Soldank::SoldierPhysics::Update(state_manager_,
+                                        current_soldier,
+                                        physics_events,
+                                        animation_data_manager_,
+                                        bullet_emitter,
+                                        gravity);
 
         if (animations_to_check_at_tick_.contains(current_tick)) {
             CheckSoldierAnimationStates(current_soldier,

--- a/tests/shared/core/physics/SoldierMovementSimulation.cpp
+++ b/tests/shared/core/physics/SoldierMovementSimulation.cpp
@@ -9,13 +9,12 @@ namespace SoldankTesting
 {
 SoldierMovementSimulation::SoldierMovementSimulation(const Soldank::IFileReader& file_reader)
 {
-    Soldank::State& state = state_manager_.GetState();
     auto map =
       SoldankTesting::MapBuilder::Empty()
         ->AddPolygon(
           { 0.0F, 0.0F }, { 100.0F, 0.0F }, { 50.0F, 50.0F }, Soldank::PMSPolygonType::Normal)
         ->Build();
-    state.map = *map;
+    state_manager_.OverrideMap(*map);
     animation_data_manager_.LoadAllAnimationDatas(file_reader);
     std::vector<Soldank::Weapon> weapons{
         { Soldank::WeaponParametersFactory::GetParameters(
@@ -25,13 +24,11 @@ SoldierMovementSimulation::SoldierMovementSimulation(const Soldank::IFileReader&
         { Soldank::WeaponParametersFactory::GetParameters(
           Soldank::WeaponType::FragGrenade, false, file_reader) }
     };
-    state.soldiers.emplace_back(
-      0,
+    state_manager_.CreateSoldier(
       animation_data_manager_,
-      Soldank::ParticleSystem::Load(Soldank::ParticleSystemType::Soldier, 4.5F, file_reader),
-      weapons);
-    state.soldiers.back().particle.position = glm::vec2{ 0.0F, -29.0F };
-    state.soldiers.back().particle.old_position = glm::vec2{ 0.0F, -29.0F };
+      0,
+      Soldank::ParticleSystem::Load(Soldank::ParticleSystemType::Soldier, 4.5F, file_reader));
+    state_manager_.SetSoldierPosition(0, { 0.0F, -29.0F });
 }
 
 void SoldierMovementSimulation::HoldRight()
@@ -120,21 +117,28 @@ void SoldierMovementSimulation::AddSoldierExpectedAnimationState(
     animations_to_check_at_tick_.at(tick).push_back(soldier_expected_animation_state);
 }
 
-void SoldierMovementSimulation::RunUntilSoldierOnGround()
+void SoldierMovementSimulation::RunUntilSoldierOnGround(unsigned int ticks_limit)
 {
     static float gravity = 0.06F;
+    ticks_limit = 5;
+    unsigned int ticks = 0;
 
-    Soldank::State& state = state_manager_.GetState();
-    auto& current_soldier = *state.soldiers.begin();
+    const auto& current_soldier = state_manager_.GetSoldier(0);
     while (!current_soldier.on_ground) {
         std::vector<Soldank::BulletParams> bullet_emitter;
         Soldank::PhysicsEvents physics_events;
-        Soldank::SoldierPhysics::Update(state_manager_,
-                                        current_soldier,
-                                        physics_events,
-                                        animation_data_manager_,
-                                        bullet_emitter,
-                                        gravity);
+        state_manager_.TransformSoldier(0, [&](auto& soldier) {
+            Soldank::SoldierPhysics::Update(state_manager_,
+                                            soldier,
+                                            physics_events,
+                                            animation_data_manager_,
+                                            bullet_emitter,
+                                            gravity);
+        });
+        ++ticks;
+        if (ticks == ticks_limit) {
+            break;
+        }
     }
 }
 
@@ -143,8 +147,7 @@ void SoldierMovementSimulation::RunFor(unsigned int ticks_to_run)
     // TODO: Move this somewhere else
     static float gravity = 0.06F;
 
-    Soldank::State& state = state_manager_.GetState();
-    auto& current_soldier = *state.soldiers.begin();
+    const auto& current_soldier = state_manager_.GetSoldier(0);
     glm::vec2 soldier_position_origin = current_soldier.particle.position;
     for (unsigned int current_tick = 0; current_tick < ticks_to_run; current_tick++) {
         if (controls_to_change_at_tick_.contains(current_tick)) {
@@ -162,12 +165,14 @@ void SoldierMovementSimulation::RunFor(unsigned int ticks_to_run)
 
         std::vector<Soldank::BulletParams> bullet_emitter;
         Soldank::PhysicsEvents physics_events;
-        Soldank::SoldierPhysics::Update(state_manager_,
-                                        current_soldier,
-                                        physics_events,
-                                        animation_data_manager_,
-                                        bullet_emitter,
-                                        gravity);
+        state_manager_.TransformSoldier(0, [&](auto& soldier) {
+            Soldank::SoldierPhysics::Update(state_manager_,
+                                            soldier,
+                                            physics_events,
+                                            animation_data_manager_,
+                                            bullet_emitter,
+                                            gravity);
+        });
 
         if (animations_to_check_at_tick_.contains(current_tick)) {
             CheckSoldierAnimationStates(current_soldier,

--- a/tests/shared/core/physics/SoldierMovementSimulation.hpp
+++ b/tests/shared/core/physics/SoldierMovementSimulation.hpp
@@ -56,7 +56,7 @@ public:
       unsigned int tick,
       const SoldierExpectedAnimationState& soldier_expected_animation_state);
 
-    void RunUntilSoldierOnGround();
+    void RunUntilSoldierOnGround(unsigned int ticks_limit = 5000);
 
     void RunFor(unsigned int ticks_to_run);
 

--- a/tests/shared/core/physics/SoldierMovementSimulation.hpp
+++ b/tests/shared/core/physics/SoldierMovementSimulation.hpp
@@ -7,6 +7,7 @@
 #include "shared_lib_testing/MapBuilder.hpp"
 
 #include <gtest/gtest.h>
+#include <memory>
 
 namespace SoldankTesting
 {
@@ -78,7 +79,7 @@ private:
     void TurnSoldierLeft();
     void TurnSoldierRight();
 
-    Soldank::StateManager state_manager_;
+    std::unique_ptr<Soldank::StateManager> state_manager_;
     Soldank::AnimationDataManager animation_data_manager_;
 
     std::unordered_map<unsigned int, SoldierExpectedAnimationStates> animations_to_check_at_tick_;


### PR DESCRIPTION
- removed all usages of raw State from callsites and made them use StateManager instead
- Changed containers to arrays for State's soldiers, items and bullets (this is better because it's not creating new objects dynamically all the time and enables easier access to objects)